### PR TITLE
BlackBerry Dynamics SDK for React Native v10.1 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,37 +3,43 @@ This page provides an overview on how to use the BlackBerry Dynamics SDK for Rea
 
 # Supportability
 #### Development environment
- - Mac OS X
+ - Mac OS
  - Windows 10 (Android only)
 #### Node.js
- - 12.x
+ - 12.x (for React Native version < 0.68.0)
+ - 14.x (for React Native version >= 0.68.0)
 #### Package manager
  - yarn
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 #### iOS
- - Xcode 12+
+ - Xcode 12, 13
  - iOS 13, 14, 15
- - cocoapods 1.10.1+
+ - cocoapods 1.10.2+
 #### Android
- - Android 8+, API 26+
+ - Java 8 (for React Native version < 0.68.0)
+ - Java 11 (for React Native version >= 0.68.0)
+ - Android 9+, API 28+
  - NDK 20.1.5948944 (for React Native version < 0.66.0)
  - NDK 21.4.7075529 (for React Native version >= 0.66.0)
 #### BlackBerry Dynamics
- - BlackBerry Dynamics SDK for iOS v9.2 and v10.0, check environment requirements [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-sdk-ios/).
- - BlackBerry Dynamics SDK for Android v9.2 and v10.0, check environment requirements [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-sdk-android/).
+ - BlackBerry Dynamics SDK for iOS v10.2, check environment requirements [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-sdk-ios/).
+ - BlackBerry Dynamics SDK for Android v10.2, check environment requirements [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-sdk-android/).
 #### BlackBerry Dynamics Launcher
- - BlackBerry Dynamics Launcher library for iOS v3.3, check details [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-launcher-framework-for-ios).
- - BlackBerry Dynamics Launcher library for Android v3.3, check details [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-launcher-framework-for-android).
+ - BlackBerry Dynamics Launcher library for iOS v3.4, check details [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-launcher-framework-for-ios).
+ - BlackBerry Dynamics Launcher library for Android v3.4, check details [here](https://docs.blackberry.com/en/development-tools/blackberry-dynamics-launcher-framework-for-android).
 
 # Features
 #### Integration with BlackBerry Dynamics
 Integration of BlackBerry Dynamics SDK for iOS and Android into React Native application is supported by addition of the `BlackBerry-Dynamics-for-React-Native-Base` module.
 ###### "Dynamic Framework" integration on iOS
 Dynamics SDK for React Native v9.0 and above integrates with the iOS "Dynamic Framework" version of BlackBerry Dynamics. The static library integration is no longer supported.
+#### Application configuration and app-specific policy
+`BlackBerry-Dynamics-for-React-Native-Application` module provides access to information that is globally available to any BlackBerry Dynamics Application. The module provides API to read Dynamcis application configuration and app-specific policy.
 #### Secure connectivity
 - Both `XMLHttpRequest` and `fetch` are secured in scope of `BlackBerry-Dynamics-for-React-Native-Networking` module.
 - `<WebView />` is secured in scope of `BlackBerry-Dynamics-for-React-Native-WebView` UI component.
@@ -81,6 +87,7 @@ More details can be found [here](https://docs.blackberry.com/en/development-tool
 # Package contents
 #### Modules
 - `BlackBerry-Dynamics-for-React-Native-Base` - automatically integrates BlackBerry Dynamics SDK for iOS and Android into React Native application
+- `BlackBerry-Dynamics-for-React-Native-Application` - provides API to read Dynamcis application configuration and app-specific policy
 - `BlackBerry-Dynamics-for-React-Native-Networking` - secures `XMLHttpRequest`, `fetch` and `WebSocket` APIs. For more details please refer to [networking](https://facebook.github.io/react-native/docs/network) topic in React Native.
 - `BlackBerry-Dynamics-for-React-Native-SQLite-Storage` - secures SQLite DB usage. It is based on [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage) 3rd party module.
 - `BlackBerry-Dynamics-for-React-Native-Async-Storage` - secures built-in [AsyncStorage](https://facebook.github.io/react-native/docs/asyncstorage#docsNav).
@@ -99,11 +106,12 @@ More details can be found [here](https://docs.blackberry.com/en/development-tool
 - `ClipboardTestApp` - demonstrates usage of [Clipboard](https://facebook.github.io/react-native/docs/clipboard) API in terms of Data Leakage Prevention. It is possible to change DLP policy on UEM and see how it affects the clipboard within the application. If DLP is on, it will not be possible to copy clipboard data from "Dynamics" application to "non-Dynamics" application and vice-versa.
 - `DLP` - demonstrates usage of `<Text />` and `<TextInput />` UI components together with DLP policy option on UEM. If DLP is on, it will not be possible to do cut-copy-paste operations over data from "Dynamics" to "non-Dynamics" application and vice-versa.
 - `SQLite` - shows example of using secure SQLite DB instance in React Native application.
-- `UnitTests` - runs Jasmine unit tests for `fetch`, `XMLHttpRequest`, `Clipboard`, `AsyncStorage`, `AppKinetics` and `SQLite` in React Native application.
+- `UnitTests` - runs Jasmine unit tests for `fetch`, `XMLHttpRequest`, `WebSocket`, `Clipboard`, `AsyncStorage`, `AppKinetics`, `Application`, `Launcher`, `FileSystem` and `SQLite` in React Native application.
 - `WebViewBrowser` - demonstrates usage of `<WebView />` UI component in React Native application.
 - `FileSystem` - shows example of using secure FileSystem instance in React Native application. It demonstrates how to manage files/directories and how to upload/download files.
 - `AppKinetics` - shows example of using AppKinetics functionality.
-- `WebSockets` - contains `WebSocketClient` and `WebSocketServer` sample apps. It demonstrates usage of secure `WebSocket` API - how to establish connection to WebSocket server using `ws://` or `wss://` protocols, how to send or receive text or binary data over WebSocket connection, how to close WebSocket connection. 
+- `WebSockets` - contains `WebSocketClient` and `WebSocketServer` sample apps. It demonstrates usage of secure `WebSocket` API - how to establish connection to WebSocket server using `ws://` or `wss://` protocols, how to send or receive text or binary data over WebSocket connection, how to close WebSocket connection.
+- `Policy` - shows example of using Application module functionality, reads Dynamcis application configuration and app-specific policy.
 
 ## Preconditions
 Make sure you first setup your environment and install BlackBerry Dynamics.
@@ -125,13 +133,14 @@ To setup, build and run the sample applications please refer to the README for e
 - [FileSystem](./SampleApplications/FileSystem/README.md)
 - [AppKinetics](./SampleApplications/AppKinetics/README.md)
 - [WebSockets](./SampleApplications/WebSockets/README.md)
+- [Policy](./SampleApplications/Policy/README.md)
 
 ### Integrate into new React Native application
 To integrate BlackBerry Dynamics into a new React Native application please follow these [steps](./modules/BlackBerry-Dynamics-for-React-Native-Base/README.md#installation).
 
 ### Integrate into existing React Native application
 To integrate BlackBerry Dynamics into existing React Native application:
- - Check you are using `0.64.x` version of React Native.
+ - Check you are using `0.66.x` or higher version of React Native.
 
       - [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) may be used to upgrade your application prior to integrating BlackBerry Dynamics. Confirm the application builds and works correctly after upgrade.
 
@@ -153,6 +162,7 @@ To integrate BlackBerry Dynamics into existing React Native application:
      - If `<TextInput />` UI component is used you can secure cut/copy/paste operations by adding `BlackBerry-Dynamics-for-React-Native-TextInput` UI component. See [TextInput UI component](./ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/README.md).
      - If `<WebView />` UI component is used you can secure resource loading within WebView by adding `BlackBerry-Dynamics-for-React-Native-WebView` UI component. See [WebView UI component](./ui-components/BlackBerry-Dynamics-for-React-Native-WebView/README.md).
 
+ - Use other Dynamics React Native modules.
  - Lastly, do not forget to update the imports in your code.
  
 ## Limitations
@@ -160,3 +170,21 @@ To integrate BlackBerry Dynamics into existing React Native application:
 Flipper cannot be used together with BlackBerry Dynamics SDK for React Native on iOS in debug configuration as it disables some BlackBerry Dynamics functionality related to secure networking.
 Flipper is disabled on iOS by default. If your Dynamics React Native application on iOS does not use Secure Connectivity feature (`BlackBerry-Dynamics-for-React-Native-Networking` module) you can enable Flipper by uncommenting `use_flipper!()` line in `Podfile` of your application.
 
+## Known issues
+### Conflict between default and secure SQLite library on iOS
+BlackBerry Dynamcis SDK for iOS uses secure *SQLite* library to provide secure DB connection and management.
+Many standard and 3rd party modules use default *SQLite* library.
+When both default and secure *SQLite* libraries are linked to the project it causes conflict with unpredictable behavior.
+##### Example: react-native-webrtc
+Let's consider a concrete example:
+**`BlackBerry-Dynamics-for-React-Native-Base`** - is main module from **BlackBerry Dynamics SDK for React Native** that integrates BlackBerry Dymamics into React Native application. BlackBerry Dymamics, in turn, provides secure *SQLite* dependency to the project.
+**`BlackBerry-Dynamics-for-React-Native-SQLite-Storage`** - module from **BlackBerry Dynamics SDK for React Native** that provides secure DB connection and management.
+**`react-native-webrtc`** links default *SQLite* library in the project. This is an extract of its podspec:
+```
+s.libraries           = 'c', 'sqlite3', 'stdc++'
+```
+When the project is compiled and run DB functionality works incorrectly.
+> NOTE: There can be more of such cases when to use **BlackBerry Dynamics SDK for React Native** module and some other module that links default SQLite library in Pods. The workaround below can be used to fix the issue.
+
+##### Workaround
+To resolve the conflict **`sqlite3`** dependency should be removed in *<app>/node_modules/react-native-webrtc/react-native-webrtc.podspec*. Then, do **"pod install"** again. This should not break anything as secured **`sqlite3`** dependency will remain linked to the project.

--- a/SampleApplications/AppKinetics/README.md
+++ b/SampleApplications/AppKinetics/README.md
@@ -1,24 +1,63 @@
 ## AppKinetics sample application
-> AppKinetics sample application shows example of using AppKinetics functionality.
+The AppKinetics sample application demonstrates:
+ - Service discovery (using **`transfer-file`** service).
+ - Sending files **to** other Dynamics applications (consumption of **`transfer-file`** service).
+ - Receive files **from** other Dynamics applications (providing **`transfer-file`** service).
+ - Compose secure emails with attachments and send them via **BlackBerry Work**.
 
-#### How to prepare the app
+## Required configuration on UEM
+In order to be able to send files to other Dynamics application the appropriate app should be properly configured on UEM and act as a service provider of **`transfer-file`** service.
+List of Dynamics application-based services can be found [here](https://marketplace.blackberry.com/services).
+
+Some Dynamics apps are already configured on UEM and have functionality to show files contents, such as:
+ - BlackBerry Work available on Apple App Store and Google Play Market
+ - Dynamics AppKinetics for [iOS](https://get.good.com/samples/ios/com.good.gd.example.appkinetics.zip) and [Android](https://get.good.com/samples/android/AppKinetics.zip)
+ - Dynamics Cordova AppKinetics Server - part of Dynamics SDK for Cordova that can be downloaded [here](https://developers.blackberry.com/us/en/resources/downloads)
+ - Dynamics Ionic-Cordova Secure-ICC available on [BlackBerry GitHub](https://github.com/blackberry/BlackBerry-Dynamics-Cordova-Samples/tree/master/Secure-ICC)
+ - Dynamics Ionic-Capacitor Secure-ICC available on [BlackBerry GitHub](https://github.com/blackberry/BlackBerry-Dynamics-Cordova-Samples/tree/master/Secure-ICC-Ionic-Capacitor-Angular)
+
+Any app from the list can be added to your user's allowed apps list on UEM and activated.
+
+#### Enable service discovery
+Any other Dynamics application can be configured and be able to act as a service provider of **`transfer-file`** service and receive files:
+1. Navigate to the "Apps" Tab
+2. Select "+"
+3. Select "Internal BlackBerry Dynamics App"
+4. Input your `GDApplicationID` / `GDApplicationVersion` from `Info.plist`
+5. Save
+6. Under `version` select the "+" option
+7. **Bind** the required services to the application
+	Select the services that the app is going to use. Enabling these in UEM ensures that other Dynamics apps can discover this app as a service provider.
+    **Examples of services:**
+	- `Transfer Multiple Files Service`
+	- `Email Message`
+	- `Transfer File Service`
+	**NOTE**: _If you do not enable **`transfer-file`** service in UEM for your Dynamics app, the AppKinetics sample will not fully function as it will not discover it as app that can receive files._
+8. Go to the "Users" Tab
+9. Assign your newly configured app to your user
+10. Proceed with activation
+
+## How to prepare the app
 Open the sample app directory in Terminal window:
 `$ cd <path>/SampleApplications/AppKinetics`
 
 Install dependencies:
 `$ yarn`
 
-> NOTE: AppKinetics sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+NOTE: AppKinetics sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
 
-## Dynamics modules
+Generate ios and android directories:
+`$ react-native eject`
+
+## Install Dynamics modules
 #### Prerequisites
 There are some dependencies that need to be installed before using `BlackBerry-Dynamics-for-React-Native-Base` module. More information can be found [here](https://github.com/blackberry/BlackBerry-Dynamics-React-Native-SDK/tree/master/modules/BlackBerry-Dynamics-for-React-Native-Base#Preconditions).
 
@@ -31,7 +70,9 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 
 > Allows to update an identifier (required) and name (optional) for your application. This identifier is your iOS Bundle ID or Android Package Name. It will also be used as the Entitlement ID for entitling and activating your application with the BlackBerry UEM management console.
 
-#### How to secure AppKinetics communication
+It is suggested to use **`com.blackberry.bbd.example.cdv.appkinetics.server`** here. An app with this ID (`Dynamics Cordova AppKinetics Server` sample app) is already configured on UEM as a service provider of **`transfer-file`** service, so it can receive files.
+
+#### How to enable ICC communication
 	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics
 
 ##### iOS
@@ -46,13 +87,62 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 ##### Android
 `$ react-native run-android`
 
-#### Examples of usage
-##### 0.64.2
+#### How to secure FileSystem
+	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem
+
+`FileSystem` module is dependent on `Networking` module, so we need to install it as well:
+
+    $ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Networking
+
+##### iOS
+`$ cd ios`  
+`$ pod install`  
+`$ cd ..`  
+
+#### How to run application
+##### iOS
+`$ react-native run-ios`
+
+##### Android
+`$ react-native run-android`
+
+## Prepare files that will be sent to other app
+In order to send files to other Dynamics applications files need to be stored in appropriate location.
+#### Android
+_`BlackBerry_Dynamics_SDK_for_React_Native_vX.X.X.X/SampleApplications/AppKinetics/android/app/src/main/assets/data`_
+#### iOS
+_`BlackBerry_Dynamics_SDK_for_React_Native_vX.X.X.X/SampleApplications/AppKinetics/ios/AppKinetics/data`_
+Also, open the app in Xcode and drag-n-drop **`data`** folder (from _`AppKinetics/ios/AppKinetics/data`_) to **`AppKinetics`** group so it is recognized as part of the project.
+
+Files then will be copied to secure container using **`copyFilesToSecureStorage`** API from `AppKinetics` module and can be transfered to other Dynamics application that is a service provider of **`transfer-file`** service.
+
+## Enable Keychain Sharing on iOS
+Both Dynamics apps that participate in Inter-Container Communication (ICC) must share the same **`com.good.gd.data`** Keychain group and have **`com.good.gd.discovery.good`** URL scheme set.
+#### Configure service consumer
+Dynamics React Native AppKinetics sample can act as service consumer of **`transfer-file`** service, in other words, it can send files to other Dynamics apps. For this to be done let's enable **`com.good.gd.data`** Keychain group and set **`com.good.gd.discovery.good`** URL scheme:
+1. Open `BlackBerry_Dynamics_SDK_for_React_Native_vX.X.X.X/SampleApplications/AppKinetics/ios/AppKinetics.xcworkspace` in Xcode
+2. Go `Signing & Capabilities` to tab
+3. Click `+` and search for `Keychain Sharing` capability
+4. Add **`com.good.gd.data`** Keychain group
+5. Go `Info` to tab
+6. Expand `URL types` section
+7. Add **`com.good.gd.discovery.good`** URL scheme
+
+#### Configure service provider
+Native Dynamics AppKinetics sample is a service provider of **`transfer-file`** service, in other words, it can receive files from other Dynamics apps. For this **`com.good.gd.data`** Keychain group and **`com.good.gd.discovery.good`** URL scheme should be configured as well:
+1. Download and unzip [native AppKinetics sample for iOS](https://get.good.com/samples/ios/com.good.gd.example.appkinetics.zip).
+2. Open `<path>/com.good.gd.example.appkinetics/AppKinetics.xcodeproj` in Xcode
+3. Do steps **2. - 7.** from the section above
+4. Install and activate
+
+## Examples of usage
+##### 0.66.4
 `$ cd <path>/SampleApplications/AppKinetics`  
 `$ yarn`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  
+It is suggested to use **`com.blackberry.bbd.example.cdv.appkinetics.client`** here. An app with this ID is already configured on UEM as a service provider of **`transfer-file`** service, so it can both send and receive files.
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Networking`  
@@ -63,14 +153,15 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/AppKinetics`  
 `$ yarn`  
 `$ cd .. ; git init ; cd AppKinetics`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
-`$ yarn set-bundle-id`  
+`$ yarn set-bundle-id`
+It is suggested to use **`com.blackberry.bbd.example.cdv.appkinetics.client`** here. An app with this ID is already configured on UEM as a service provider of **`transfer-file`** service, so it can both send and receive files.
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Networking`  

--- a/SampleApplications/AppKinetics/package.json
+++ b/SampleApplications/AppKinetics/package.json
@@ -12,8 +12,8 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.34",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-native-fontawesome": "^0.2.6",
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "react-native-svg": "^12.1.0"
   },
   "devDependencies": {
@@ -23,8 +23,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/AppKinetics/src/components/IosStyleModal.js
+++ b/SampleApplications/AppKinetics/src/components/IosStyleModal.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { View, Modal, Text, StyleSheet } from 'react-native';
-import { TransparentButton } from '../components';
+import { TransparentButton } from './TransparentButton';
 import { theme } from '../static';
 
 export const IosStyleModal = ({visible, title, onShow, children, buttons}) => (

--- a/SampleApplications/AppKinetics/src/context/ApplicationContext.js
+++ b/SampleApplications/AppKinetics/src/context/ApplicationContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,34 +14,24 @@
  * limitations under the License.
  */
 
-import React, {createContext, useContext} from 'react';
-import {NativeEventEmitter, NativeModules} from 'react-native';
-import {ShowContentScreen} from '../screens/ShowContentScreen';
+import React from 'react';
+import { NativeEventEmitter, NativeModules } from 'react-native';
+import { ShowContentScreen } from '../screens/ShowContentScreen';
 import {
   faCheckCircle,
   faExclamationCircle,
   faComment,
 } from '@fortawesome/free-solid-svg-icons';
-import {ToastMessage} from '../components/ToastMessage';
+import { ToastMessage } from '../components/ToastMessage';
 import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
 import BbdAppKinetics from 'BlackBerry-Dynamics-for-React-Native-AppKinetics';
-import {SAVE_FILE_SERVICE, TRANSFER_FILE_SERVICE} from '../static';
+import { SAVE_FILE_SERVICE, TRANSFER_FILE_SERVICE } from '../static';
+
+import { ApplicationContext } from './context';
 
 const eventEmitter = new NativeEventEmitter(
   NativeModules.ReactNativeBbdAppKinetics,
 );
-
-export const ApplicationContext = createContext();
-
-export const useNavigation = () => {
-  const {screen} = useContext(ApplicationContext);
-  return screen;
-};
-
-export const useNotification = () => {
-  const {notification} = useContext(ApplicationContext);
-  return notification;
-};
 
 class ApplicationProvider extends React.Component {
   constructor(props) {
@@ -110,7 +100,8 @@ class ApplicationProvider extends React.Component {
 
   async componentDidMount() {
     try {
-      await BbdAppKinetics.copyFilesToSecureStorage();
+      const result = await BbdAppKinetics.copyFilesToSecureStorage();
+      console.log('Copy files to secure storage result: ', JSON.stringify(result));
       await BbdAppKinetics.readyToProvideService(
         TRANSFER_FILE_SERVICE.ID,
         TRANSFER_FILE_SERVICE.VERSION,
@@ -212,4 +203,4 @@ class ApplicationProvider extends React.Component {
   }
 }
 
-export {ApplicationProvider};
+export { ApplicationProvider };

--- a/SampleApplications/AppKinetics/src/context/context.js
+++ b/SampleApplications/AppKinetics/src/context/context.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from 'react';
+
+export const ApplicationContext = createContext();

--- a/SampleApplications/AppKinetics/src/context/hooks.js
+++ b/SampleApplications/AppKinetics/src/context/hooks.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+import { ApplicationContext } from './context';
+
+export const useNavigation = () => {
+   const { screen } = useContext(ApplicationContext);
+   return screen;
+};
+
+export const useNotification = () => {
+   const { notification } = useContext(ApplicationContext);
+   return notification;
+};

--- a/SampleApplications/AppKinetics/src/screens/HomeScreen.js
+++ b/SampleApplications/AppKinetics/src/screens/HomeScreen.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React, {useState, useEffect} from 'react';
-import {View, Text, StyleSheet, SafeAreaView, ScrollView} from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, SafeAreaView, ScrollView } from 'react-native';
 import {
   BottomArea,
   BottomTabBar,
@@ -27,14 +27,14 @@ import {
   TabButton,
   AngleRightButton,
 } from '../components';
-import {faFolder, faPaperPlane} from '@fortawesome/free-solid-svg-icons';
-import {useNavigation, useNotification} from '../context/ApplicationContext';
-import {ShowContentScreen} from './ShowContentScreen';
-import {theme} from '../static';
+import { faFolder, faPaperPlane } from '@fortawesome/free-solid-svg-icons';
+import { useNavigation, useNotification } from '../context/hooks';
+import { ShowContentScreen } from './ShowContentScreen';
+import { theme } from '../static';
 
 import BbdAppKinetics from 'BlackBerry-Dynamics-for-React-Native-AppKinetics';
 import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
-import {TRANSFER_FILE_SERVICE} from '../static';
+import { TRANSFER_FILE_SERVICE } from '../static';
 
 export const HomeScreen = () => {
   const nav = useNavigation();

--- a/SampleApplications/AppKinetics/src/screens/SendEmailScreen.js
+++ b/SampleApplications/AppKinetics/src/screens/SendEmailScreen.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import {
   IosStyleModal as Modal
 } from '../components';
 import { faFolder, faPaperPlane } from '@fortawesome/free-solid-svg-icons';
-import { useNavigation, useNotification } from '../context/ApplicationContext';
+import { useNavigation, useNotification } from '../context/hooks';
 import { theme } from '../static';
 
 import BbdAppKinetics from 'BlackBerry-Dynamics-for-React-Native-AppKinetics';

--- a/SampleApplications/AppKinetics/src/screens/ShowContentScreen.js
+++ b/SampleApplications/AppKinetics/src/screens/ShowContentScreen.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import {
   Header,
   BottomArea
 } from '../components';
-import { useNavigation } from '../context/ApplicationContext';
+import { useNavigation } from '../context/hooks';
 import { theme } from '../static';
 
 export const ShowContentScreen = ({title, content, textAlign}) => {

--- a/SampleApplications/BasicNetworking/README.md
+++ b/SampleApplications/BasicNetworking/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: BasicNetworking sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: BasicNetworking sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -48,7 +48,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/BasicNetworking`  
 `$ yarn`  
 `$ react-native eject`  
@@ -62,11 +62,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/BasicNetworking`  
 `$ yarn`  
 `$ cd .. ; git init ; cd BasicNetworking`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  

--- a/SampleApplications/BasicNetworking/package.json
+++ b/SampleApplications/BasicNetworking/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "js-base64": "^2.5.1",
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "react-native-document-picker": "^3.2.4",
     "url": "^0.11.0"
   },
@@ -19,8 +19,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/ClipboardTestApp/README.md
+++ b/SampleApplications/ClipboardTestApp/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: ClipboardTestApp sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: ClipboardTestApp sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -46,7 +46,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/ClipboardTestApp`  
 `$ yarn`  
 `$ react-native eject`  
@@ -60,11 +60,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`  
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/ClipboardTestApp`  
 `$ yarn`  
 `$ cd .. ; git init ; cd ClipboardTestApp`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  

--- a/SampleApplications/ClipboardTestApp/package.json
+++ b/SampleApplications/ClipboardTestApp/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "BlackBerry Dynamics ClipboardTestApp sample",
   "dependencies": {
-    "react": "17.0.1",
-    "react-native": "0.64.2"
+    "react": "17.0.2",
+    "react-native": "0.66.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -13,8 +13,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/DLP/App.js
+++ b/SampleApplications/DLP/App.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
 import React, {Component} from 'react';
 import { StyleSheet, View, SafeAreaView, KeyboardAvoidingView, ScrollView } from 'react-native';
 
-import { SearchBar, Input } from 'react-native-elements';
-import Icon from 'react-native-vector-icons/FontAwesome';
+// DEVNOTE: Uncomment this to use UI components from "react-native-elements", see additional info at README.md
+// import { SearchBar, Input } from 'react-native-elements';
+// import Icon from 'react-native-vector-icons/FontAwesome';
 
 import TextInput from 'BlackBerry-Dynamics-for-React-Native-TextInput';
 import Text from 'BlackBerry-Dynamics-for-React-Native-Text';
@@ -115,7 +116,8 @@ export default class App extends Component {
               />
             </View>
 
-            <Text style={styles.pageHeader}>react-native-elements</Text>
+            {/* Uncomment this to show block with UI components from "react-native-elements" */}
+            {/* <Text style={styles.pageHeader}>react-native-elements</Text>
             <View>
               <SearchBar
                 placeholder="RN-Elements: Search bar"
@@ -142,7 +144,7 @@ export default class App extends Component {
                   />
                 }
               />
-            </View>
+            </View> */}
 
           </ScrollView>
         </KeyboardAvoidingView>

--- a/SampleApplications/DLP/README.md
+++ b/SampleApplications/DLP/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: DLP sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: DLP sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -66,7 +66,7 @@ import TextInput from 'BlackBerry-Dynamics-for-React-Native-TextInput';
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/DLP`  
 `$ yarn`  
 `$ react-native eject`  
@@ -82,11 +82,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`  
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/DLP`  
 `$ yarn`  
 `$ cd .. ; git init ; cd DLP`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  

--- a/SampleApplications/DLP/package.json
+++ b/SampleApplications/DLP/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "BlackBerry Dynamics DLP sample",
   "dependencies": {
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "react-native-elements": "^1.1.0",
     "react-native-vector-icons": "^7.0.0"
   },
@@ -15,8 +15,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/FileSystem/App.js
+++ b/SampleApplications/FileSystem/App.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import React, { createContext, useState } from 'react';
+import React, { useState } from 'react';
 import { screens } from './src/context/ScreenContext';
 import { NotificationProvider } from './src/context/NotificationContext';
 import { ApplicationProvider } from './src/context/ApplicationContext';
-
-export const ScreenContext = createContext();
+import { ScreenContext } from './src/context/context';
 
 const App = () => {
   const [_screen, setScreen] = useState([screens.main]);

--- a/SampleApplications/FileSystem/README.md
+++ b/SampleApplications/FileSystem/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: FileSystem sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: FileSystem sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -53,7 +53,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/FileSystem`
 `$ yarn`
 `$ react-native eject`
@@ -68,11 +68,11 @@ For iOS:
 `$ react-native run-ios`
 For Android:
 `$ react-native run-android`
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/FileSystem`
 `$ yarn`
 `$ cd .. ; git init ; cd FileSystem`
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.68.2`
 `$ react-native eject`
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`
 `$ yarn set-bundle-id`

--- a/SampleApplications/FileSystem/package.json
+++ b/SampleApplications/FileSystem/package.json
@@ -12,8 +12,8 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/react-native-fontawesome": "^0.2.6",
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "react-native-svg": "^12.1.0"
   },
   "devDependencies": {
@@ -23,8 +23,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/FileSystem/src/components/FileListItem.js
+++ b/SampleApplications/FileSystem/src/components/FileListItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableHighlight } from 'react-native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faTrashAlt, faCopy, faUpload, faFileAlt, faFileImport } from '@fortawesome/free-solid-svg-icons';
 import { colorScheme } from '../theme';
 import { MoreButton } from './MoreButton';
-import { ApplicationContext } from '../context/ApplicationContext';
 import { IconButton } from './IconButton';
-import { NotificationContext } from '../context/NotificationContext';
+import { useNotification, useStorage } from '../context/hooks';
 import { UploadFileModal } from './modal/UploadFileModal';
 import { MoveFileModal } from './modal/MoveFileModal';
 
@@ -31,11 +30,11 @@ import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
 
 const iconSize = 22;
 
-export const FileListItem = ({name, path, size, onPress, onReload}) => {
+export const FileListItem = ({ name, path, size, onPress, onReload }) => {
   const [showSubItems, setShowSubItems] = useState(false);
 
-  const { storage, bottomSheet } = useContext(ApplicationContext);
-  const { notification } = useContext(NotificationContext);
+  const { storage, bottomSheet } = useStorage();
+  const { notification } = useNotification();
 
   const removeItem = async () => {
     setShowSubItems(!showSubItems);
@@ -67,7 +66,7 @@ export const FileListItem = ({name, path, size, onPress, onReload}) => {
     setShowSubItems(!showSubItems);
     try {
       let fileName = path.lastPathComponent();
-      let {name} = fileName.exposeNameAndExtension();
+      let { name } = fileName.exposeNameAndExtension();
       let type = 'text/plain'; // there is no API to get file's mime type: https://github.com/itinance/react-native-fs/issues/910
       bottomSheet.show(
         <UploadFileModal
@@ -77,7 +76,7 @@ export const FileListItem = ({name, path, size, onPress, onReload}) => {
             filepath: path,
             filetype: type
           }}
-          onDismiss={() => {bottomSheet.hide()}}
+          onDismiss={() => { bottomSheet.hide() }}
         />
       );
     } catch (error) {
@@ -99,7 +98,7 @@ export const FileListItem = ({name, path, size, onPress, onReload}) => {
           notification.emmit('success', `File "${name}" moved.`);
         }}
         onError={(message) => notification.emmit('alert', message)}
-        onDismiss={() => {bottomSheet.hide()}}
+        onDismiss={() => { bottomSheet.hide() }}
       />
     );
   };

--- a/SampleApplications/FileSystem/src/components/FolderListItem.js
+++ b/SampleApplications/FileSystem/src/components/FolderListItem.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import React, { useState, useContext } from 'react';
+import React, { useState, } from 'react';
 import { View, Text, StyleSheet, TouchableHighlight } from 'react-native';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faTrashAlt, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { colorScheme } from '../theme';
 import { MoreButton } from './MoreButton';
 import { IconButton } from './IconButton';
-import { NotificationContext } from '../context/NotificationContext';
+import { useNotification } from '../context/hooks';
 
 import FileSystemService from '../services/file-system.service';
 
 const iconSize = 22;
 
-export const FolderListItem = ({name, path, size, onPress, onReload}) => {
+export const FolderListItem = ({ name, path, size, onPress, onReload }) => {
   const [showSubItems, setShowSubItems] = useState(false);
 
-  const { notification } = useContext(NotificationContext);
+  const { notification } = useNotification();
 
   const removeItem = async () => {
     setShowSubItems(!showSubItems);

--- a/SampleApplications/FileSystem/src/components/modal/CreateFolderModal.js
+++ b/SampleApplications/FileSystem/src/components/modal/CreateFolderModal.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import FileSystemService from '../../services/file-system.service';
 import { BottomSheet } from './BottomSheet';
 import { CustomButton } from '../CustomButton';
-import { NotificationContext } from '../../context/NotificationContext';
 import { colorScheme } from '../../theme';
 import { validate } from '../../services/validation.service';
 import { CustomTextInput } from '../CustomTextInput';
+import { useNotification } from '../../context/hooks';
 
-export const CreateFolderModal = ({path, onSubmit, onDismiss}) => {
-  const { notification } = useContext(NotificationContext);
+export const CreateFolderModal = ({ path, onSubmit, onDismiss }) => {
+  const { notification } = useNotification();
   const [name, setName] = useState('');
 
   const [validationError, setValidationError] = useState({
@@ -61,8 +61,8 @@ export const CreateFolderModal = ({path, onSubmit, onDismiss}) => {
           onChangeText={folderNameHandler}
           validationError={validationError.name}
         />
-        <View style={{height: 10}} />
-        { name && name.trim().length > 0 ? (
+        <View style={{ height: 10 }} />
+        {name && name.trim().length > 0 ? (
           <CustomButton
             title="Create Folder"
             disabled={!!validationError.name}
@@ -71,7 +71,7 @@ export const CreateFolderModal = ({path, onSubmit, onDismiss}) => {
           :
           null
         }
-        <View style={{height: 10}} />
+        <View style={{ height: 10 }} />
         <CustomButton
           title="Close"
           color={colorScheme.red}

--- a/SampleApplications/FileSystem/src/components/modal/CreateTxtFile.js
+++ b/SampleApplications/FileSystem/src/components/modal/CreateTxtFile.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { colorScheme } from '../../theme';
 import { CustomButton } from '../CustomButton';
-import { ApplicationContext} from '../../context/ApplicationContext';
-import { NotificationContext } from '../../context/NotificationContext';
 import { BottomSheet } from './BottomSheet';
 import { validate } from '../../services/validation.service';
 import { CustomTextInput } from '../CustomTextInput';
 
 import FileSystemService from '../../services/file-system.service';
+import { useNotification, useStorage } from '../../context/hooks';
 
-export const CreateTxtFile = ({visible, onSubmit, onDismiss}) => {
-  const { storage } = useContext(ApplicationContext);
-  const { notification } = useContext(NotificationContext);
+export const CreateTxtFile = ({ visible, onSubmit, onDismiss }) => {
+  const { storage } = useStorage();
+  const { notification } = useNotification();
 
   const [name, setName] = useState('');
   const [validationError, setValidationError] = useState({
@@ -71,8 +70,8 @@ export const CreateTxtFile = ({visible, onSubmit, onDismiss}) => {
           onChangeText={fileNameHandler}
           validationError={validationError.name}
         />
-        <View style={{height: 10}} />
-        { name && name.trim().length > 0 ? (
+        <View style={{ height: 10 }} />
+        {name && name.trim().length > 0 ? (
           <CustomButton
             title="Create File"
             disabled={!!validationError.name}
@@ -82,7 +81,7 @@ export const CreateTxtFile = ({visible, onSubmit, onDismiss}) => {
           null
         }
 
-        <View style={{height: 10}} />
+        <View style={{ height: 10 }} />
         <CustomButton
           title="Close"
           color={colorScheme.red}

--- a/SampleApplications/FileSystem/src/components/modal/DownloadFileModal.js
+++ b/SampleApplications/FileSystem/src/components/modal/DownloadFileModal.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-import React, { useContext, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import { BottomSheet } from './BottomSheet';
 import { CustomButton } from '../CustomButton';
-import { NotificationContext } from '../../context/NotificationContext';
 import { colorScheme } from '../../theme';
-import { ApplicationContext } from '../../context/ApplicationContext';
 import { validate } from '../../services/validation.service';
 import { CustomTextInput } from '../CustomTextInput';
+import { useNotification, useStorage } from '../../context/hooks';
 
-import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem'
+import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
 
-export const DownloadFileModal = ({onSubmit, onDownloadEnd, onDismiss}) => {
-  const { notification } = useContext(NotificationContext);
-  const { storage } = useContext(ApplicationContext);
+export const DownloadFileModal = ({ onSubmit, onDownloadEnd, onDismiss }) => {
+  const { notification } = useNotification();
+  const { storage } = useStorage();
 
   const [url, setUrl] = useState('http://www.textfiles.com/programming/24hrs.txt');
   const [name, setName] = useState('');
@@ -38,10 +37,10 @@ export const DownloadFileModal = ({onSubmit, onDownloadEnd, onDismiss}) => {
   });
 
   useEffect(() => {
-    let validated = { url: null, name: null};
+    let validated = { url: null, name: null };
 
     const urlPattern = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi;
-    if(!urlPattern.test(url)) {
+    if (!urlPattern.test(url)) {
       validated.url = 'Please provide correct url!';
     }
 
@@ -77,10 +76,10 @@ export const DownloadFileModal = ({onSubmit, onDownloadEnd, onDismiss}) => {
 
       downloadTask.promise
         .then((res) => {
-          if(res.statusCode === 200) {
+          if (res.statusCode === 200) {
             onDownloadEnd()
           } else {
-            notification.emmit('alert', 'File doesn\'t exist at path.');
+            notification.emmit('alert', 'File can\'t be downloaded from following URL.');
           }
         })
         .catch((error) => {
@@ -108,8 +107,8 @@ export const DownloadFileModal = ({onSubmit, onDownloadEnd, onDismiss}) => {
           onChangeText={nameHandler}
           validationError={validationError.name}
         />
-        <View style={{height: 10}} />
-        { name && name.trim().length > 0 ? (
+        <View style={{ height: 10 }} />
+        {name && name.trim().length > 0 ? (
           <CustomButton
             title={'Download file'}
             disabled={!!validationError.name || !!validationError.url}
@@ -118,7 +117,7 @@ export const DownloadFileModal = ({onSubmit, onDownloadEnd, onDismiss}) => {
           :
           null
         }
-        <View style={{height: 10}} />
+        <View style={{ height: 10 }} />
         <CustomButton
           title="Close"
           color={colorScheme.red}

--- a/SampleApplications/FileSystem/src/context/ApplicationContext.js
+++ b/SampleApplications/FileSystem/src/context/ApplicationContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import React, { createContext, useState } from 'react';
+import React, { useState } from 'react';
 import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
+import { ApplicationContext } from './context';
 
-export const ApplicationContext = createContext();
-
-export const ApplicationProvider = ({children}) => {
+export const ApplicationProvider = ({ children }) => {
   const [root, setRoot] = useState(FS.DocumentDirectoryPath);
   const [currentPath, setCurrentPath] = useState(root);
   const [modal, setModal] = useState(null);
@@ -41,7 +40,6 @@ export const ApplicationProvider = ({children}) => {
     set entries(entries) {
       setEntries(entries)
     },
-    reload() {},
   };
 
   const bottomSheet = {

--- a/SampleApplications/FileSystem/src/context/NotificationContext.js
+++ b/SampleApplications/FileSystem/src/context/NotificationContext.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,58 +14,57 @@
  * limitations under the License.
  */
 
-import React, { createContext, useState } from 'react';
+import React, { useState } from 'react';
 import { ToastMessage } from '../components/ToastMessage';
 import { faCheckCircle, faExclamationCircle, faExclamationTriangle, faComment } from '@fortawesome/free-solid-svg-icons'
+import { NotificationContext } from './context';
 
-export const NotificationContext = createContext();
-
-export const NotificationProvider = ({children}) => {
+export const NotificationProvider = ({ children }) => {
   const [notification, setNotification] = useState(null);
 
   const emmit = (type, message) => {
-    switch(type) {
+    switch (type) {
       case 'alert':
         setNotification(
-        <ToastMessage
-          icon={faExclamationCircle}
-          color="red"
-          message={message}
-          onDismiss={() => setNotification(null)}
-        />);
+          <ToastMessage
+            icon={faExclamationCircle}
+            color="red"
+            message={message}
+            onDismiss={() => setNotification(null)}
+          />);
         break;
       case 'warning':
         setNotification(
-        <ToastMessage
-          icon={faExclamationTriangle}
-          color="yellow"
-          message={message}
-          onDismiss={() => setNotification(null)}
-        />);
+          <ToastMessage
+            icon={faExclamationTriangle}
+            color="yellow"
+            message={message}
+            onDismiss={() => setNotification(null)}
+          />);
         break;
       case 'success':
         setNotification(
-        <ToastMessage
-          icon={faCheckCircle}
-          color="green"
-          message={message}
-          onDismiss={() => setNotification(null)}
-        />);
+          <ToastMessage
+            icon={faCheckCircle}
+            color="green"
+            message={message}
+            onDismiss={() => setNotification(null)}
+          />);
         break;
       default:
         setNotification(
-        <ToastMessage
-          icon={faComment}
-          color="#ccc"
-          message={message}
-          onDismiss={() => setNotification(null)}
-        />);
+          <ToastMessage
+            icon={faComment}
+            color="#ccc"
+            message={message}
+            onDismiss={() => setNotification(null)}
+          />);
     }
   };
 
   return (
     <NotificationContext.Provider value={{
-      notification: {emmit}
+      notification: { emmit }
     }}>
       {children}
       {notification}

--- a/SampleApplications/FileSystem/src/context/context.js
+++ b/SampleApplications/FileSystem/src/context/context.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext } from 'react';
+
+export const ApplicationContext = createContext();
+
+export const ScreenContext = createContext();
+
+export const NotificationContext = createContext();

--- a/SampleApplications/FileSystem/src/context/hooks.js
+++ b/SampleApplications/FileSystem/src/context/hooks.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext } from 'react';
+import { ApplicationContext, ScreenContext, NotificationContext } from './context';
+
+export const useNavigation = () => {
+   return useContext(ScreenContext);
+};
+
+export const useNotification = () => {
+   return useContext(NotificationContext);
+};
+
+export const useStorage = () => {
+   return useContext(ApplicationContext);
+};

--- a/SampleApplications/FileSystem/src/screens/MainScreen.js
+++ b/SampleApplications/FileSystem/src/screens/MainScreen.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import { faPlus, faFolderOpen, faFileAlt, faDownload } from '@fortawesome/free-solid-svg-icons';
-
-import { ScreenContext } from '../../App';
-import { NotificationContext } from '../context/NotificationContext';
 import { ViewEditFileScreen } from './ViewEditFileScreen';
 import { FloatingActionButton } from '../components/FloatingActionButton';
 import { Header } from '../components/Header';
@@ -29,16 +26,15 @@ import { BackListItem } from '../components/BackListItem';
 import { CreateTxtFile } from '../components/modal/CreateTxtFile';
 import { colorScheme } from '../theme';
 import { CreateFolderModal } from '../components/modal/CreateFolderModal';
-import { ApplicationContext } from '../context/ApplicationContext';
 import { DownloadFileModal } from '../components/modal/DownloadFileModal';
 import { NoEntries } from '../components/NoEntries';
-
 import FS from 'BlackBerry-Dynamics-for-React-Native-FileSystem';
+import { useNavigation, useNotification, useStorage } from '../context/hooks';
 
 export const MainScreen = () => {
-  const { storage } = useContext(ApplicationContext);
-  const { screen } = useContext(ScreenContext);
-  const { notification } = useContext(NotificationContext);
+  const { storage } = useStorage();
+  const { screen } = useNavigation();
+  const { notification } = useNotification();
 
   const [modal, setModal] = useState(null);
 

--- a/SampleApplications/FileSystem/src/screens/ViewEditFileScreen.js
+++ b/SampleApplications/FileSystem/src/screens/ViewEditFileScreen.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,27 @@
  * limitations under the License.
  */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Text,
   StyleSheet,
   View,
   ScrollView,
   TextInput,
-  Dimensions,
   KeyboardAvoidingView,
   Platform
 } from 'react-native';
 import FileSystemService from '../services/file-system.service';
-import { ScreenContext } from '../../App';
-import { NotificationContext } from '../context/NotificationContext';
 import { Header } from '../components/Header';
 import { IconButton, icons } from '../components/IconButton';
 import { FloatingButton } from '../components/FloatingButton';
 import { colorScheme } from '../theme';
 import { faSave, faEdit } from '@fortawesome/free-solid-svg-icons';
-
-const screenHeight = Math.round(Dimensions.get('window').height);
+import { useNavigation, useNotification } from '../context/hooks';
 
 export const ViewEditFileScreen = ({ source }) => {
-  const { screen } = useContext(ScreenContext);
-  const { notification } = useContext(NotificationContext);
+  const { screen } = useNavigation();
+  const { notification } = useNotification();
 
   const [file, setFile] = useState(source);
   const [edit, setEdit] = useState(false);

--- a/SampleApplications/Policy/3RD_PARTY_LICENSES.txt
+++ b/SampleApplications/Policy/3RD_PARTY_LICENSES.txt
@@ -1,0 +1,25 @@
+MIT License  
+  
+Copyright (c) 2015-present, Facebook, Inc.  
+  
+Permission is hereby granted, free of charge, to any person obtaining a copy  
+of this software and associated documentation files (the "Software"), to deal  
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell  
+copies of the Software, and to permit persons to whom the Software is  
+furnished to do so, subject to the following conditions:  
+  
+The above copyright notice and this permission notice shall be included in all  
+copies or substantial portions of the Software.  
+  
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE. 
+*********************************************************************************************** 
+ 
+Copyright (c) 2021 BlackBerry Limited. All Rights Reserved. 
+._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._. 

--- a/SampleApplications/Policy/App.js
+++ b/SampleApplications/Policy/App.js
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { StyleSheet, SafeAreaView, View, NativeEventEmitter, NativeModules } from 'react-native';
+
+import { ShowItemsList } from './components/ShowItemsList';
+import { ApplicationHeader } from './components/ApplicationHeader';
+import { NavigationTab } from './components/NavigationTab';
+
+import BbdApplication from 'BlackBerry-Dynamics-for-React-Native-Application';
+// Import native part of module to use Event Emitter
+const { BbdRNApplication } = NativeModules;
+
+export default class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTab: 'config',
+      applicationConfig: {},
+      applicationPolicy: {}
+    };
+  }
+  eventEmitter = new NativeEventEmitter(BbdRNApplication);
+  NAVIGATION_TABS = [
+    {
+      name: 'config',
+      title: 'App config'
+    },
+    {
+      name: 'app',
+      title: 'App policy'
+    }
+  ];
+
+  componentDidMount() {
+    this.handlePolicyByType(this.state.activeTab);
+    this.addEventListeners();
+  }
+
+  componentWillUnmount() {
+    this.onAppPolicyUpdateListener.remove();
+    this.onPolicyErrorListener.remove();
+    this.onAppConfigUpdateListener.remove();
+  }
+
+  addEventListeners() {
+    // Event is fired when app-specific policy is updated
+    this.onAppConfigUpdateListener = this.eventEmitter.addListener('onAppConfigUpdate', applicationConfig => {
+      this.setState({ applicationConfig });
+      console.log('onAppConfigUpdate event: ', JSON.stringify(applicationConfig));
+    });
+    // Event is fired when app-config policy is updated
+    this.onAppPolicyUpdateListener = this.eventEmitter.addListener('onAppPolicyUpdate', applicationPolicy => {
+      this.setState({ applicationPolicy });
+      console.log('onAppPolicyUpdate event: ', JSON.stringify(applicationPolicy));
+    });
+    this.onPolicyErrorListener = this.eventEmitter.addListener('onError', error => {
+      console.error('onError event: ', JSON.stringify(error));
+    });
+
+  }
+
+  handlePolicyByType(policyType) {
+    switch (policyType) {
+      case 'config':
+        this.getAppConfigPolicy();
+        break;
+      case 'app':
+        this.getAppSpecificPolicy();
+        break;
+      default:
+        break;
+    }
+  }
+
+  async getAppConfigPolicy() {
+    try {
+      const applicationConfig = await BbdApplication.getApplicationConfig();
+      this.setState({ applicationConfig });
+      console.log('App-config policy received:', applicationConfig);
+    } catch (error) {
+      alert('Failed to get app-config policy!' + error.message);
+    }
+  }
+
+  async getAppSpecificPolicy() {
+    try {
+      const applicationPolicy = await BbdApplication.getApplicationPolicy();
+      this.setState({ applicationPolicy });
+      console.log('App-specific policy received:', applicationPolicy);
+    } catch (error) {
+      alert('Failed to get app-specific policy!' + error.message);
+    }
+
+  }
+
+  renderActiveTab() {
+    let activeTab;
+
+    switch (this.state.activeTab) {
+      case 'config':
+        activeTab = this.state.applicationConfig && (
+          <ShowItemsList
+            header='App-configuration policy'
+            objectData={this.state.applicationConfig}>
+          </ShowItemsList>
+        );
+        break;
+      case 'app':
+        activeTab = this.state.applicationConfig && (
+          <ShowItemsList
+            header='App-specific policy'
+            objectData={this.state.applicationPolicy}>
+          </ShowItemsList>
+        );
+        break;
+      default:
+        activeTab = null;
+        break;
+    }
+
+    return activeTab;
+  }
+
+  selectActiveTab = tab => {
+    this.handlePolicyByType(tab);
+    this.setState({ activeTab: tab });
+  }
+
+  render() {
+    const { activeTab } = this.state;
+
+    return (
+      <SafeAreaView style={{ flex: 1, backgroundColor: '#fff' }}>
+        <ApplicationHeader name="Policy"></ApplicationHeader>
+        <View style={styles.container}>
+          {this.renderActiveTab()}
+        </View>
+        <View style={styles.tabsDelimiter}></View>
+        <NavigationTab
+          tabs={this.NAVIGATION_TABS}
+          activeTab={activeTab}
+          onChangeTab={this.selectActiveTab}
+        >
+        </NavigationTab>
+      </SafeAreaView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingBottom: 28
+  },
+  tabsDelimiter: {
+    borderColor: '#edf6f9',
+    borderWidth: 1
+  }
+});

--- a/SampleApplications/Policy/LICENSE
+++ b/SampleApplications/Policy/LICENSE
@@ -1,0 +1,201 @@
+                             Apache License
+                       Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/SampleApplications/Policy/README.md
+++ b/SampleApplications/Policy/README.md
@@ -1,0 +1,79 @@
+## Policy sample application
+> Policy sample application shows example of usage API, which provides access to information that is globally available to any BlackBerry Dynamics Application. It demonstrates how to retrieve a collection of application configuration and application-specific policy settings. Retrieval of policy settings is happening during method call, or whenever settings are changed (event-based approach).
+
+#### How to prepare the app
+Open the sample app directory in Terminal window:
+`$ cd <path>/SampleApplications/Policy`
+
+Install dependencies:
+`$ yarn`
+
+> NOTE: Policy sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
+`$ react-native upgrade 0.6x.x`
+for example:
+`$ react-native upgrade 0.67.4`
+or
+`$ react-native upgrade 0.68.2`
+
+Generate ios and android directories:
+`$ react-native eject`
+
+## Dynamics modules
+#### Prerequisites
+There are some dependencies that need to be installed before using `BlackBerry-Dynamics-for-React-Native-Base` module. More information can be found [here](https://github.com/blackberry/BlackBerry-Dynamics-React-Native-SDK/tree/master/modules/BlackBerry-Dynamics-for-React-Native-Base#Preconditions).
+
+#### How to integrate Dynamics into application
+	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base
+
+> Integrates Dynamics based on your current identifiers - iOS Bundle ID and Android Package Name.
+
+	$ yarn set-bundle-id (Optional step, but required for sample applications)
+
+> Allows to update an identifier (required) and name (optional) for your application. This identifier is your iOS Bundle ID or Android Package Name. It will also be used as the Entitlement ID for entitling and activating your application with the BlackBerry UEM management console.
+
+#### How to add Application module
+	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application
+
+##### iOS
+`$ cd ios`  
+`$ pod install`  
+`$ cd ..`
+
+#### How to run application
+##### iOS
+`$ react-native run-ios`
+
+##### Android
+`$ react-native run-android`
+
+#### Examples of usage
+##### 0.66.4
+`$ cd <path>/SampleApplications/Policy`  
+`$ yarn`  
+`$ react-native eject`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
+`$ yarn set-bundle-id`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application`  
+For iOS:  
+`$ cd ios`  
+`$ pod install`  
+`$ cd ..`  
+`$ react-native run-ios`  
+For Android:  
+`$ react-native run-android`
+##### 0.68.2
+`$ cd <path>/SampleApplications/Policy`  
+`$ yarn`  
+`$ cd .. ; git init ; cd Policy`  
+`$ react-native upgrade 0.68.2`  
+`$ react-native eject`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
+`$ yarn set-bundle-id`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application`  
+For iOS:  
+`$ cd ios`  
+`$ pod install`  
+`$ cd ..`  
+`$ react-native run-ios`  
+For Android:  
+`$ react-native run-android`

--- a/SampleApplications/Policy/__tests__/App-test.js
+++ b/SampleApplications/Policy/__tests__/App-test.js
@@ -1,0 +1,14 @@
+/**
+ * @format
+ */
+
+import 'react-native';
+import React from 'react';
+import App from '../App';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+
+it('renders correctly', () => {
+  renderer.create(<App />);
+});

--- a/SampleApplications/Policy/app.json
+++ b/SampleApplications/Policy/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "Policy",
+  "displayName": "Policy"
+}

--- a/SampleApplications/Policy/babel.config.js
+++ b/SampleApplications/Policy/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/SampleApplications/Policy/components/ApplicationHeader.js
+++ b/SampleApplications/Policy/components/ApplicationHeader.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+
+export const ApplicationHeader = props => {
+  return (
+    <Text style={styles.header}>{props.name}</Text>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    paddingTop: 10,
+    paddingBottom: 5,
+    paddingHorizontal: 12,
+    color: '#4486f5',
+    fontSize: 22,
+    fontWeight: 'bold'
+  }
+});

--- a/SampleApplications/Policy/components/NavigationTab.js
+++ b/SampleApplications/Policy/components/NavigationTab.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+
+export const NavigationTab = props => {
+  const { tabs, activeTab, onChangeTab } = props;
+
+  return (
+    <View style={styles.tabsRow}>
+      {
+        tabs.map(tab => (
+          <TouchableOpacity
+            style={[
+              styles.tabButton,
+              { backgroundColor: activeTab === tab.name ? '#edf4ff' : '#fff' }
+            ]}
+            key={tab.name}
+            onPress={() => { onChangeTab(tab.name) }}
+          >
+            <Text style={styles.tabText}>{tab.title}</Text>
+          </TouchableOpacity>
+        ))
+      }
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  tabsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: 'center',
+    padding: 10
+  },
+  tabText: {
+    color: '#000'
+  }
+});

--- a/SampleApplications/Policy/components/ShowItemsList.js
+++ b/SampleApplications/Policy/components/ShowItemsList.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Platform, StyleSheet, Text, View, FlatList } from 'react-native';
+
+export const ShowItemsList = props => {
+  const { header, objectData } = props;
+
+  const renderItem = ({item}) => (
+    <View style={styles.listItemContainer}>
+      <Text style={styles.listItemFont}>
+        <Text style={styles.listItemKey}>{item}: </Text>
+        { renderObjectOrValue(objectData[item]) }
+      </Text>
+    </View>
+  );
+
+  const renderObjectOrValue = itemValue => {
+    if (Array.isArray(itemValue)) {
+      let arrayAsString = '';
+
+      itemValue.forEach(item => {
+        arrayAsString += `\n  ${JSON.stringify(item)},`;
+      });
+
+      return `[${removeEndLineComma(arrayAsString)}\n]`;
+    } else if (typeof itemValue === 'object' && itemValue !== null) {
+      let objectAsString = '{';
+
+      for (const key in itemValue) {
+        objectAsString += `\n  ${key}: ${JSON.stringify(itemValue[key])},`;
+      }
+
+      return `${removeEndLineComma(objectAsString)}\n}`;
+    }
+
+    return JSON.stringify(itemValue);
+  }
+
+  const removeEndLineComma = str => {
+    return str[str.length - 1] === ',' ? str.slice(0, -1) : str;
+  }
+
+  return (
+    <View>
+      <Text style={styles.listTitle}>{header}</Text>
+      <FlatList
+        data={Object.keys(objectData)}
+        renderItem={renderItem}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  listItemContainer: {
+    paddingHorizontal: 18,
+    paddingVertical: 6
+  },
+  listItemFont: {
+    fontSize: 14,
+    fontFamily: Platform.OS === 'ios' ? 'CourierNewPSMT' : 'monospace',
+    color: '#000'
+  },
+  listTitle: {
+    textAlign: 'center',
+    paddingVertical: 5,
+    fontWeight: 'bold',
+    fontSize: 16,
+    color: '#000'
+  },
+  listItemKey: {
+    fontWeight: 'bold',
+    fontFamily: 'Arial'
+  }
+});

--- a/SampleApplications/Policy/index.js
+++ b/SampleApplications/Policy/index.js
@@ -1,0 +1,9 @@
+/**
+ * @format
+ */
+
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/SampleApplications/Policy/metro.config.js
+++ b/SampleApplications/Policy/metro.config.js
@@ -1,0 +1,17 @@
+/**
+ * Metro configuration for React Native
+ * https://github.com/facebook/react-native
+ *
+ * @format
+ */
+
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
+};

--- a/SampleApplications/Policy/package.json
+++ b/SampleApplications/Policy/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "Policy",
+  "version": "1.0.0",
+  "description": "BlackBerry Dynamics Policy sample",
+  "dependencies": {
+    "react": "17.0.2",
+    "react-native": "0.66.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.17.9",
+    "@babel/runtime": "^7.17.9",
+    "@react-native-community/eslint-config": "^3.0.1",
+    "babel-jest": "^28.0.2",
+    "eslint": "^8.14.0",
+    "jest": "^28.0.2",
+    "metro-react-native-babel-preset": "^0.70.2",
+    "react-test-renderer": "17.0.2",
+    "react-native-eject": "^0.1.2"
+  },
+  "license": "SEE LICENSE IN LICENSE",
+  "jest": {
+    "preset": "react-native"
+  }
+}

--- a/SampleApplications/README.md
+++ b/SampleApplications/README.md
@@ -1,10 +1,11 @@
 # Sample Applications
 
 ## Supportability
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## General tips
 
@@ -49,8 +50,19 @@ Generate ios and android directories:
 	$ pod install
 	$ cd ..
 
+#### How to add Application module
+	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application
+###### iOS
+	$ cd ios
+	$ pod install
+	$ cd ..
+
 #### How to secure Networking
 	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Networking
+###### iOS
+	$ cd ios
+	$ pod install
+	$ cd ..
 
 #### How to secure AsyncStorage
 	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Async-Storage

--- a/SampleApplications/SQLite/README.md
+++ b/SampleApplications/SQLite/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: SQLite sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: SQLite sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -50,7 +50,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/SQLite`  
 `$ yarn`  
 `$ react-native eject`  
@@ -66,11 +66,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`  
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/SQLite`  
 `$ yarn`  
 `$ cd .. ; git init ; cd SQLite`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  

--- a/SampleApplications/SQLite/package.json
+++ b/SampleApplications/SQLite/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-picker/picker": "^1.14.0",
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.0.0",
@@ -24,8 +24,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/UnitTests/README.md
+++ b/SampleApplications/UnitTests/README.md
@@ -1,5 +1,5 @@
 ## UnitTests sample application
-> UnitTests sample application runs Jasmine unit tests for `fetch`, `XMLHttpRequest`, `Clipboard`, `AsyncStorage`, `SQLite` and `AppKinetics`, `FileSystem`, `Launcher` in React Native application.
+> UnitTests sample application runs Jasmine unit tests for `fetch`, `XMLHttpRequest`, `Clipboard`, `AsyncStorage`, `SQLite` and `AppKinetics`, `FileSystem`, `Launcher`, `Application` in React Native application.
 
 #### How to prepare the app
 Open the sample app directory in Terminal window:
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: UnitTests sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, 0.65.1 or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: UnitTests sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -48,8 +48,11 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 #### How to secure FileSystem
 	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem
 
-#### How to add Launcher
+#### How to add Launcher module
 	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Launcher
+
+#### How to add Application module
+	$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application
 
 ##### iOS
 `$ cd ios`  
@@ -65,7 +68,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/UnitTests`  
 `$ yarn`  
 `$ react-native eject`  
@@ -78,6 +81,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Launcher`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application`  
 For iOS:  
 `$ cd ios`  
 `$ pod install`  
@@ -86,11 +90,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`  
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/UnitTests`  
 `$ yarn`  
 `$ cd .. ; git init ; cd UnitTests`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  
@@ -101,6 +105,7 @@ For Android:
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-FileSystem`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Launcher`  
+`$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application`  
 For iOS:  
 `$ cd ios`  
 `$ pod install`  

--- a/SampleApplications/UnitTests/components/TestRunnerComponent.js
+++ b/SampleApplications/UnitTests/components/TestRunnerComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,8 +134,8 @@ export default class TestRunnerComponent extends Component {
     if (this.state.jasmineReporterResults.suites && this.state.jasmineReporterResults.suites.length > 0) {
       let suiteChildren = this.state.jasmineReporterResults.suites.filter(suite => suite.parent === parent);
 
-      return suiteChildren && suiteChildren.length > 0 ? suiteChildren.map((suite, index) => (
-        <View key={index} style={styles.container}>
+      return suiteChildren && suiteChildren.length > 0 ? suiteChildren.map((suite) => (
+        <View key={_.uniqueId()} style={styles.container}>
           <View style={{ paddingLeft: 8 }}>
             <Text
               style={[styles.specsResultsFont, styles.suiteTitle]}
@@ -143,14 +143,11 @@ export default class TestRunnerComponent extends Component {
               {suite.description}
             </Text>
 
-            {suite.specs && suite.specs.length > 0 ?
-              <FlatList
-                data={suite.specs}
-                ref={flatList => { this.flatList = flatList }}
-                keyExtractor={(item, index) => item.id}
-                renderItem={({ item }) => this.renderSpecResult(item)}
-                onContentSizeChange={() => { this.testResultsScrollView.scrollToEnd() }}
-              />
+            {suite.specs && suite.specs.length > 0 ? suite.specs.map((spec) => (
+              <View key={_.uniqueId()}>
+                {this.renderSpecResult(spec)}
+              </View>)
+              )
               :
               null
             }
@@ -188,7 +185,7 @@ export default class TestRunnerComponent extends Component {
 
       return (
         <Text
-          key={index}
+          key={_.uniqueId()}
           style={[styles.testStatusIcon, styles[specResult.specClass]]}>
           {symbol}
         </Text>
@@ -256,7 +253,7 @@ export default class TestRunnerComponent extends Component {
                   <Text>No expectations: {jasmineReporterResults.statistic.noExpectationSpecsCounter}</Text>
                 </Text>
               </View>
-            )
+              )
               :
               null
           }
@@ -267,7 +264,8 @@ export default class TestRunnerComponent extends Component {
 
         <ScrollView
           style={{ paddingHorizontal: 3 }}
-          ref={scrollView => { this.testResultsScrollView = scrollView }}>
+          ref={scrollView => { this.testResultsScrollView = scrollView }}
+          onContentSizeChange={() => {this.testResultsScrollView.scrollToEnd()}}>
           {this.renderSuiteResultsByParent('')}
         </ScrollView>
 
@@ -319,8 +317,8 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap'
   },
   testStatusIcon: {
-    fontSize: 20,
-    maxWidth: 20
+    fontSize: 18,
+    maxWidth: 18
   },
   testPassed: {
     color: '#007069'

--- a/SampleApplications/UnitTests/package.json
+++ b/SampleApplications/UnitTests/package.json
@@ -6,8 +6,8 @@
     "install": "node ./scripts/copyAssetsFiles.js"
   },
   "dependencies": {
-    "react": "17.0.1",
-    "react-native": "0.64.2",
+    "react": "17.0.2",
+    "react-native": "0.66.4",
     "js-base64": "^2.5.1",
     "rxjs": "^6.5.3",
     "async": "^2.6.1",
@@ -20,8 +20,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/UnitTests/tests/TestRunner.js
+++ b/SampleApplications/UnitTests/tests/TestRunner.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import runSpecsForAsyncStorage from './specs/testAsyncStorage';
 import runSpecsForAppKinetics from './specs/testAppKinetics';
 import runSpecsForFileSystem from './specs/testFileSystem';
 import runSpecsForLauncher from './specs/testLauncher';
+import runSpecsForApplication from './specs/testApplication';
 
 export default {
   execute: function() {
@@ -182,6 +183,7 @@ export default {
     runSpecsForAppKinetics();
     runSpecsForFileSystem();
     runSpecsForLauncher();
+    runSpecsForApplication();
 
     // Run tests
     env.execute();

--- a/SampleApplications/UnitTests/tests/specs/testApplication.js
+++ b/SampleApplications/UnitTests/tests/specs/testApplication.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import BbdApplication from 'BlackBerry-Dynamics-for-React-Native-Application';
+
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+const { BbdRNApplication } = NativeModules;
+const eventEmitter = new NativeEventEmitter(BbdRNApplication);
+
+export default function() {
+  describe('BbdApplication API', function() {
+
+    it('Check BbdApplication is available', function() {
+      expect(BbdApplication).toBeDefined();
+    });
+
+    describe('BbdApplication basic functionality', function() {
+      let onAppConfigUpdateListener;
+      let onAppPolicyUpdateListener;
+      let onPolicyErrorListener;
+
+      beforeAll(function() {
+        onAppConfigUpdateListener = eventEmitter.addListener('onAppConfigUpdate', applicationConfig => { });
+        onAppPolicyUpdateListener = eventEmitter.addListener('onAppPolicyUpdate', applicationConfig => { });
+        onPolicyErrorListener = eventEmitter.addListener('onError', onError => { });
+      });
+
+      afterAll(function() {
+        onAppConfigUpdateListener.remove();
+        onAppPolicyUpdateListener.remove();
+        onPolicyErrorListener.remove();
+      });
+
+      it("Check BbdApplication API", function() {
+        let isAvailableAllApplicationMethods = true;
+        const applicationMethodsMock = [
+          'getApplicationConfig',
+          'getApplicationPolicy'
+        ];
+
+        const ApplicationAPI = Object.getOwnPropertyNames(BbdApplication.constructor.prototype)
+          .filter(key => key !== 'constructor');
+
+        for (let i = 0; i < applicationMethodsMock.length; i++) {
+          if (!ApplicationAPI.includes(applicationMethodsMock[i])) {
+            isAvailableAllApplicationMethods = false;
+            break;
+          }
+        }
+
+        expect(isAvailableAllApplicationMethods).toBe(true);
+      });
+
+      it('BbdApplication: getApplicationConfig - check reponse JSON is not empty', async function() {
+        const applicationConfig = await BbdApplication.getApplicationConfig();
+
+        expect(applicationConfig).toBeDefined();
+        expect(typeof applicationConfig).toBe('object');
+        expect(Object.keys(applicationConfig).length).toBeGreaterThan(0);
+      });
+
+      it('BbdApplication: getApplicationConfig - check reponse JSON structure', async function() {
+        const expectedResponseObjTypes = {
+          appHost: 'string',
+          appPort: 'number',
+          appServers: 'array',
+          communicationProtocols: 'object',
+          containerId: 'string',
+          copyPasteOn: 'boolean',
+          detailedLogsOn: 'boolean',
+          enterpriseId: 'string',
+          enterpriseIdActivated: 'boolean',
+          enterpriseIdFeatures: 'array',
+          extraInfo: 'object',
+          keyboardRestrictedMode: 'boolean',
+          preventAndroidDictation: 'boolean',
+          preventDictation: 'boolean',
+          preventKeyboardExtensions: 'boolean',
+          preventPasteFromNonGDApps: 'boolean',
+          preventCustomKeyboards: 'boolean',
+          preventScreenCapture: 'boolean',
+          preventScreenRecording: 'boolean',
+          preventUserDetailedLogs: 'boolean',
+          protectedByPassword: 'boolean',
+          upn: 'string',
+          userId: 'string'
+        };
+        let isExpectedValueTypes = true;
+
+        const applicationConfig = await BbdApplication.getApplicationConfig();
+
+        expect(applicationConfig).toBeDefined();
+        expect(typeof applicationConfig).toBe('object');
+
+        const responseKeys = Object.keys(applicationConfig);
+
+        for (const key of responseKeys) {
+          const currentItemType = expectedResponseObjTypes[key];
+          if (currentItemType && (typeof applicationConfig[key] !== currentItemType)) {
+            if (!(currentItemType === 'array' && Array.isArray(applicationConfig[key]))) {
+              isExpectedValueTypes = false;
+              break;
+            }
+          }
+        }
+
+        expect(isExpectedValueTypes).toBe(true);
+      });
+
+      it('BbdApplication: getApplicationPolicy - check reponse is not empty', async function() {
+        const applicationPolicy = await BbdApplication.getApplicationPolicy();
+
+        expect(applicationPolicy).toBeDefined();
+        expect(typeof applicationPolicy).toBe('object');
+      });
+
+    });
+
+  });
+}

--- a/SampleApplications/UnitTests/tests/specs/testFetch.js
+++ b/SampleApplications/UnitTests/tests/specs/testFetch.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -598,7 +598,7 @@ export default function() {
 
       it('Fetch: response type: blob', async function() {
         const method = 'GET';
-        const url = 'https://via.placeholder.com/720';
+        const url = 'https://commons.wikimedia.org/wiki/File:Test_rillke2.jpg';
 
         const response = await fetch(url, {
           method

--- a/SampleApplications/UnitTests/tests/specs/testWebSockets.js
+++ b/SampleApplications/UnitTests/tests/specs/testWebSockets.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -664,7 +664,7 @@ export default function() {
       it('WebSocket: get image as Blob by fetch, send and receive it as Blob', async function(done) {
         const url = 'wss://javascript.info/article/websocket/chat/ws';
         const method = 'GET';
-        const imageUrl = 'https://via.placeholder.com/720';
+        const imageUrl = 'https://commons.wikimedia.org/wiki/File:Test_rillke2.jpg';
         let isConditionChecked = false;
 
         const response = await fetch(imageUrl, {

--- a/SampleApplications/UnitTests/tests/specs/testXMLHttpRequest.js
+++ b/SampleApplications/UnitTests/tests/specs/testXMLHttpRequest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1389,7 +1389,7 @@ export default function() {
 
       it('XMLHttpRequest responseType: blob', function(done) {
         const method = "GET";
-        const url = "https://via.placeholder.com/720";
+        const url = "https://commons.wikimedia.org/wiki/File:Test_rillke2.jpg";
         const responseType = "blob";
 
         const xhr = new XMLHttpRequest();
@@ -1423,7 +1423,7 @@ export default function() {
 
       it('XMLHttpRequest responseType: arraybuffer', function(done) {
         const method = "GET";
-        const url = "https://via.placeholder.com/720";
+        const url = "https://commons.wikimedia.org/wiki/File:Test_rillke2.jpg";
         const responseType = "arraybuffer";
 
         const xhr = new XMLHttpRequest();

--- a/SampleApplications/WebSockets/WebSocketClient/README.md
+++ b/SampleApplications/WebSockets/WebSocketClient/README.md
@@ -8,12 +8,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: WebSocketClient sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: WebSocketClient sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -47,7 +47,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-android`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 `$ cd <path>/SampleApplications/WebSockets/WebSocketClient`  
 `$ yarn`  
 `$ react-native eject`  
@@ -61,11 +61,11 @@ For iOS:
 `$ react-native run-ios`  
 For Android:  
 `$ react-native run-android`
-##### 0.65.1
+##### 0.68.2
 `$ cd <path>/SampleApplications/WebSockets/WebSocketClient`  
 `$ yarn`  
 `$ cd .. ; git init ; cd WebSocketClient`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`  
 `$ yarn set-bundle-id`  

--- a/SampleApplications/WebSockets/WebSocketClient/package.json
+++ b/SampleApplications/WebSockets/WebSocketClient/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "BlackBerry Dynamics WebSockets sample",
   "dependencies": {
-    "react": "17.0.1",
-    "react-native": "0.64.2"
+    "react": "17.0.2",
+    "react-native": "0.66.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -13,8 +13,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/SampleApplications/WebViewBrowser/App.js
+++ b/SampleApplications/WebViewBrowser/App.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ export default class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      url: 'https://google.com',
+      url: 'https://www.google.com',
       modalVisible: false,
       permissions: []
     };
@@ -65,11 +65,9 @@ export default class App extends Component {
   }
 
   onLoadEnd(syntheticEvent) {
-    if (Platform.OS === "ios") {
-      this.setState({
-        url: syntheticEvent.nativeEvent.url
-      });
-    }
+    this.setState({
+      url: syntheticEvent.nativeEvent.url
+    });
   }
 
   onReload() {

--- a/SampleApplications/WebViewBrowser/README.md
+++ b/SampleApplications/WebViewBrowser/README.md
@@ -11,12 +11,12 @@ Open the sample app directory in Terminal window:
 Install dependencies:
 `$ yarn`
 
-> NOTE: WebViewBrowser sample is based on `0.64.2` version of React Native. There is a possibility to upgrade to `0.65.0`, `0.65.1` or `0.66.0`, `0.66.1` versions by running following command:
+> NOTE: WebViewBrowser sample is based on `0.66.4` version of React Native. There is a possibility to upgrade to `0.67.x` or `0.68.x` versions (`0.67.0` - `0.67.4`, `0.68.0` - `0.68.2`) by running one of following commands:
 `$ react-native upgrade 0.6x.x`
 for example:
-`$ react-native upgrade 0.65.1`
+`$ react-native upgrade 0.67.4`
 or
-`$ react-native upgrade 0.66.1`
+`$ react-native upgrade 0.68.2`
 
 Generate ios and android directories:
 `$ react-native eject`
@@ -45,7 +45,7 @@ There are some dependencies that need to be installed before using `BlackBerry-D
 `$ react-native run-ios`
 
 #### Examples of usage
-##### 0.64.2
+##### 0.66.4
 For Android:  
 `$ cd <path>/SampleApplications/WebViewBrowser`  
 `$ yarn`  
@@ -65,11 +65,11 @@ For iOS:
 `$ pod install`  
 `$ cd ..`  
 `$ react-native run-ios`  
-##### 0.65.1 
+##### 0.68.2 
 `$ cd <path>/SampleApplications/WebViewBrowser`  
 `$ yarn`  
 `$ cd .. ; git init ; cd WebViewBrowser`  
-`$ react-native upgrade 0.65.1`  
+`$ react-native upgrade 0.68.2`  
 `$ react-native eject`  
 `$ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base`
 `$ yarn set-bundle-id`  

--- a/SampleApplications/WebViewBrowser/package.json
+++ b/SampleApplications/WebViewBrowser/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "BlackBerry Dynamics WebViewBrowser sample",
   "dependencies": {
-    "react": "17.0.1",
-    "react-native": "0.64.2"
+    "react": "17.0.2",
+    "react-native": "0.66.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -13,8 +13,8 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
+    "react-test-renderer": "17.0.2",
     "react-native-eject": "^0.1.2",
     "react-native-codegen": "^0.0.7"
   },

--- a/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/README.md
@@ -6,10 +6,11 @@ For more details please refer to [com.good.gd.icc](https://developer.blackberry.
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-AppKinetics` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.
@@ -234,7 +235,7 @@ Dynamics React Native application should be subscribed on `onError` event in ord
 **Example of usage**
 ```typescript
 import BbdAppKinetics from 'BlackBerry-Dynamics-for-React-Native-AppKinetics';
-import { NativeEventEmitter } from 'react-native';
+import { NativeEventEmitter, NativeModules } from 'react-native';
 
 async function testAppKinetics() {
     try {
@@ -245,7 +246,7 @@ async function testAppKinetics() {
     }
 }
 
-const eventEmitter = new NativeEventEmitter(BbdAppKinetics);
+const eventEmitter = new NativeEventEmitter(NativeModules.ReactNativeBbdAppKinetics);
 
 // subscribe on onReceivedFile
 // event is fired when you receive file sent by 'com.good.gdservice.transfer-file' service
@@ -271,9 +272,9 @@ testAppKinetics();
 #### Secure storage helper
 
 ###### _copyFilesToSecureStorage_() : Promise<{copiedInThisCall: `Array<string>`, securedDataDirEntries: `Array<string>`}>
-`copyFilesToSecureStorage` API recursively copies files and directories from public `data` folder that is located in application bunlde to `/data` in secure container:
+`copyFilesToSecureStorage` API recursively copies files and directories from public `data` folder that is located in application bundle to `/data` in secure container:
  - On Android it copies from `<app>/android/app/src/main/assets/data` folder
- - On iOS it copies from `<app>/ios/<app_name>/data` folder
+ - On iOS it copies from linked `<app>/ios/<app_name>/data` folder: open the app in Xcode and drag-n-drop **`data`** folder (from _`<app>/ios/<app_name>/data`_) to **`<app_name>`** group so it is recognized as part of the project.
 
 `copyFilesToSecureStorage` returns object with following structure:
 ```typescript

--- a/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,6 @@ android {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/android/src/main/java/com/blackberry/bbd/reactnative/appkinetics/ReactNativeBbdAppKineticsModule.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-AppKinetics/android/src/main/java/com/blackberry/bbd/reactnative/appkinetics/ReactNativeBbdAppKineticsModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,7 +235,7 @@ public class ReactNativeBbdAppKineticsModule extends ReactContextBaseJavaModule 
       File gdDataFolder = gdFileSystemDelegate.createFile(root + BBD_DATA_FOLDER_PATH);
       if (fileList.length > 0 &&
               !gdDataFolder.exists()) {
-        gdDataFolder.mkdir();
+        gdDataFolder.mkdirs();
       }
 
       for (final String fileName : fileList) {

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/.flowconfig
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/.flowconfig
@@ -1,0 +1,99 @@
+[ignore]
+; We fork some components by platform
+.*/*[.]android.js
+
+; Ignore "BUCK" generated dirs
+<PROJECT_ROOT>/\.buckd/
+
+; Ignore unexpected extra "@providesModule"
+.*/node_modules/.*/node_modules/fbjs/.*
+
+; Ignore duplicate module providers
+; For RN Apps installed via npm, "Libraries" folder is inside
+; "node_modules/react-native" but in the source repo it is in the root
+node_modules/react-native/Libraries/react-native/React.js
+
+; Ignore polyfills
+node_modules/react-native/Libraries/polyfills/.*
+
+; These should not be required directly
+; require from fbjs/lib instead: require('fbjs/lib/warning')
+node_modules/warning/.*
+
+; Flow doesn't support platforms
+.*/Libraries/Utilities/HMRLoadingView.js
+
+[untyped]
+.*/node_modules/@react-native-community/cli/.*/.*
+
+[include]
+
+[libs]
+node_modules/react-native/Libraries/react-native/react-native-interface.js
+node_modules/react-native/flow/
+
+[options]
+emoji=true
+
+esproposal.optional_chaining=enable
+esproposal.nullish_coalescing=enable
+
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.ios.js
+
+module.system=haste
+module.system.haste.use_name_reducers=true
+# get basename
+module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
+# strip .js or .js.flow suffix
+module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
+# strip .ios suffix
+module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
+module.system.haste.paths.blacklist=.*/__tests__/.*
+module.system.haste.paths.blacklist=.*/__mocks__/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/Libraries/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/RNTester/.*
+module.system.haste.paths.whitelist=<PROJECT_ROOT>/node_modules/react-native/IntegrationTests/.*
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/react-native/react-native-implementation.js
+module.system.haste.paths.blacklist=<PROJECT_ROOT>/node_modules/react-native/Libraries/Animated/src/polyfills/.*
+
+munge_underscores=true
+
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+
+suppress_type=$FlowIssue
+suppress_type=$FlowFixMe
+suppress_type=$FlowFixMeProps
+suppress_type=$FlowFixMeState
+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
+
+[lints]
+sketchy-null-number=warn
+sketchy-null-mixed=warn
+sketchy-number=warn
+untyped-type-import=warn
+nonstrict-import=warn
+deprecated-type=warn
+unsafe-getters-setters=warn
+inexact-spread=warn
+unnecessary-invariant=warn
+signature-verification-failure=warn
+deprecated-utility=error
+
+[strict]
+deprecated-type
+nonstrict-import
+sketchy-null
+unclear-type
+unsafe-getters-setters
+untyped-import
+untyped-type-import
+
+[version]
+^0.98.0

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/.gitattributes
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj -text

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/.gitignore
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/.gitignore
@@ -1,0 +1,46 @@
+
+# OSX
+#
+.DS_Store
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+  
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+      
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+      

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/3RD_PARTY_LICENSES.txt
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/3RD_PARTY_LICENSES.txt
@@ -1,0 +1,25 @@
+MIT License  
+  
+Copyright (c) 2015-present, Facebook, Inc.  
+  
+Permission is hereby granted, free of charge, to any person obtaining a copy  
+of this software and associated documentation files (the "Software"), to deal  
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell  
+copies of the Software, and to permit persons to whom the Software is  
+furnished to do so, subject to the following conditions:  
+  
+The above copyright notice and this permission notice shall be included in all  
+copies or substantial portions of the Software.  
+  
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR  
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,  
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER  
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE. 
+*********************************************************************************************** 
+ 
+Copyright (c) 2022 BlackBerry Limited. All Rights Reserved. 
+._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._._. 

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/LICENSE
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/LICENSE
@@ -1,0 +1,202 @@
+                             Apache License
+                       Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/README.md
@@ -1,0 +1,134 @@
+# BlackBerry-Dynamics-for-React-Native-Application
+
+`BlackBerry-Dynamics-for-React-Native-Application` provides access to information that is globally available to any BlackBerry Dynamics Application.
+
+## Supportability
+#### React Native
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
+
+## Preconditions
+`BlackBerry-Dynamics-for-React-Native-Application` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.
+
+Please install `BlackBerry-Dynamics-for-React-Native-Base` first.
+## Installation
+
+    $ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Application
+
+###### iOS
+    $ cd ios
+    $ pod install
+    $ cd ..
+    $ react-native run-ios
+###### Android
+    $ react-native run-android
+
+## API
+
+**`<ApplicationConfig>` definition**
+```typescript
+type ApplicationConfig = {
+  appHost?: ?string,
+  appPort?: ?number,
+  appServers?: ?Array<{
+    port: ?number,
+    priority: ?number,
+    server: ?string
+  }>,
+  communicationProtocols?: ?{[key: string]: boolean},
+  containerId?: ?string,
+  copyPasteOn?: ?boolean,
+  detailedLogsOn?: ?boolean,
+  enterpriseId?: ?string,
+  enterpriseIdActivated?: ?boolean,
+  enterpriseIdFeatures?: ?Array<string>,
+  extraInfo?: ?{[key: string]: string},
+  keyboardRestrictedMode?: ?boolean,
+  preventAndroidDictation?: ?boolean,
+  preventDictation?: ?boolean,
+  preventKeyboardExtensions?: ?boolean,
+  preventPasteFromNonGDApps?: ?boolean,
+  preventScreenCapture?: ?boolean,
+  preventUserDetailedLogs?: ?boolean,
+  preventCustomKeyboards?: ?boolean,
+  preventScreenRecording?: ?boolean,
+  protectedByPassword?: ?boolean,
+  upn?: ?string,
+  userId?: ?string
+};
+```
+
+###### _getApplicationConfig_() : Promise<`ApplicationConfig`>
+`getApplicationConfig` method returns a collection of application configuration and other settings. The settings will have been made in the enterprise management console, retrieved by the BlackBerry Dynamics runtime and exposed to the application. Retrieval of configuration settings may happen during method call , or whenever settings are changed in the enterprise management console. When changed settings have been retrieved by the module's native code, a `onAppConfigUpdate` event will be dispatched to the application. Also, `onError` event will be dispatched to the application in case of unexpected issue.
+More details can be found on API reference for [iOS](https://developer.blackberry.com/files/blackberry-dynamics/ios/interface_g_di_o_s.html#a3265c6148406a8850ba673b26e472ece) and [Android](https://developer.blackberry.com/devzone/files/blackberry-dynamics/android/classcom_1_1good_1_1gd_1_1_g_d_android.html#aedeeab3604d3316fee1fda12cda56b8f).
+
+**Example of usage**
+```typescript
+import BbdApplication from 'BlackBerry-Dynamics-for-React-Native-Application';
+import { NativeEventEmitter, NativeModules  } from 'react-native';
+
+const { BbdRNApplication } = NativeModules;
+const eventEmitter = new NativeEventEmitter(BbdRNApplication);
+
+eventEmitter.addListener('onError', (error) => {
+  console.log('error occured:', error);
+});
+
+eventEmitter.addListener('onAppConfigUpdate', (config) => {
+  console.log('application config changed:', config);
+});
+
+async function getAppConfig() {
+  try {
+    const result = await BbdApplication.getApplicationConfig();
+    console.log('application config:', result);
+  } catch (error) {
+    console.log('error:', error);
+  }
+}
+getAppConfig();
+```
+
+###### _getApplicationPolicy_() : Promise<{ [key: `string`]: any }>
+`getApplicationPolicy` method returns a collection of application-specific policy settings. The settings will have been made in the management console, and retrieved by the BlackBerry Dynamics runtime. Retrieval of policy settings may happen during method call, or whenever settings are changed. When changed settings have been retrieved by the module's native code, a `onAppPolicyUpdate` event will be dispatched to the application. Also, `onError` event will be dispatched to the application in case of unexpected issue.
+More details can be found on API reference for [iOS](https://developer.blackberry.com/files/blackberry-dynamics/ios/interface_g_di_o_s.html#ab40707775bc35418b21f721652b11e75) and [Android](https://developer.blackberry.com/devzone/files/blackberry-dynamics/android/classcom_1_1good_1_1gd_1_1_g_d_android.html#a25c299a3e75e43f4021e029f563d2da6).
+For more documentation of the feature and how application policies are defined, see the [Application Policies Definition](https://developer.blackberry.com/devzone/files/blackberry-dynamics/android/_app_policies.html) documentation.
+
+**Example of usage**
+```typescript
+import BbdApplication from 'BlackBerry-Dynamics-for-React-Native-Application';
+import { NativeEventEmitter, NativeModules  } from 'react-native';
+
+const { BbdRNApplication } = NativeModules;
+const eventEmitter = new NativeEventEmitter(BbdRNApplication);
+
+eventEmitter.addListener('onAppPolicyUpdate', (config) => {
+  console.log('app-specific policy changed:', config);
+});
+
+eventEmitter.addListener('onError', (error) => {
+  console.log('error occured:', error);
+});
+
+async function getAppPolicy() {
+  try {
+    const result = await BbdApplication.getApplicationPolicy();
+    console.log('app-specific policy:', result);
+  } catch (error) {
+    console.log('error:', error);
+  }
+}
+getAppPolicy();
+```
+
+## Uninstallation
+    $ cd <appFolder>
+    $ yarn remove BlackBerry-Dynamics-for-React-Native-Application
+
+###### iOS
+    $ cd ios
+    $ pod install
+    $ cd ..

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/build.gradle
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: "com.android.library"
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-native:+'
+    implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/AndroidManifest.xml
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.blackberry.bbd.reactnative.application">
+
+</manifest>
+  

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppConfigModel.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppConfigModel.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackberry.bbd.reactnative.application;
+
+import android.util.Log;
+import com.good.gd.GDAndroid;
+import com.good.gd.error.GDNotAuthorizedError;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Observable;
+
+public class BbdAppConfigModel extends Observable {
+    private static final String tag = BbdAppConfigModel.class.getSimpleName();
+    private static BbdAppConfigModel instance;
+    private final GDAndroid gdAndroid;
+    private Map<String, Object> appConfigMap;
+
+    /**
+     * The constructor sets initial values of settings or sets empty values in case of unauthorized state
+     */
+    private BbdAppConfigModel() {
+        Log.d(tag, "+ ApplicationConfigModel()");
+        gdAndroid = GDAndroid.getInstance();
+        try {
+            appConfigMap = gdAndroid.getApplicationConfig();
+        } catch (GDNotAuthorizedError e) {
+            Log.d(tag, "GDNotAuthorizedError " + e.getMessage());
+            appConfigMap = new HashMap<String, Object>();
+        }
+    }
+
+    /**
+     * @return return single shared instance of class
+     */
+    public static synchronized BbdAppConfigModel getInstance() {
+        if (instance == null) {
+            instance = new BbdAppConfigModel();
+        }
+        return instance;
+    }
+
+    /**
+     * The updateAppConfig method updates model with new values of application settings by the
+     * BlackBerry Dynamics Runtime calls and notifies observers about changes
+     */
+    public void updateAppConfig() {
+        Log.d(tag, "+ updateAppConfig()");
+        synchronized (this) {
+            try {
+                appConfigMap = gdAndroid.getApplicationConfig();
+            } catch (GDNotAuthorizedError e) {
+                Log.d(tag, "GDNotAuthorizedError " + e.getMessage());
+                // Set empty values in case of unauthorized state
+                appConfigMap = new HashMap<String, Object>();
+            }
+
+        }
+
+        setChanged();
+        notifyObservers();
+        Log.d(tag, "- updateAppConfig()");
+    }
+
+    /**
+     * @return a collection of application settings
+     */
+    public synchronized Map<String, Object> getAppConfigMap() {
+        return appConfigMap;
+    }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppEventListener.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppEventListener.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackberry.bbd.reactnative.application;
+
+import com.good.gd.GDAppEvent;
+import com.good.gd.GDAppEventListener;
+import com.good.gd.GDAppEventType;
+
+public class BbdAppEventListener implements GDAppEventListener {
+
+    /**
+     * onGDEvent - handles events from the GD library including authorization
+     * and withdrawal of authorization, policies updating.
+     *
+     * @see com.good.gd.GDAppEventListener#onGDEvent(com.good.gd.GDAppEvent)
+     */
+    public void onGDEvent(final GDAppEvent anEvent) {
+        // Get event type
+        final GDAppEventType eventType = anEvent.getEventType();
+
+        // Get a shared instance of application policy model
+        final BbdAppPolicyModel appSpecificPolicyModel = BbdAppPolicyModel.getInstance();
+        // Get a shared instance of application settings model
+        final BbdAppConfigModel appConfigModel = BbdAppConfigModel.getInstance();
+
+        if (eventType == GDAppEventType.GDAppEventPolicyUpdate) {
+            // Update application policy after receiving of an event about a change to one or more
+            // application-specific policy settings
+            appSpecificPolicyModel.updateAppPolicy();
+        } else if (eventType == GDAppEventType.GDAppEventRemoteSettingsUpdate) {
+            // Update application settings after receiving of an event about a change to one or more
+            // application settings
+            appConfigModel.updateAppConfig();
+        }
+    }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppPolicyModel.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdAppPolicyModel.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackberry.bbd.reactnative.application;
+
+import android.util.Log;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Observable;
+import com.good.gd.GDAndroid;
+import com.good.gd.error.GDNotAuthorizedError;
+
+public class BbdAppPolicyModel extends Observable {
+    private static final String tag = BbdAppPolicyModel.class.getSimpleName();
+    private static BbdAppPolicyModel instance;
+    private final GDAndroid gdAndroid;
+    private Map<String, Object> appPolicyMap;
+
+    /**
+     * The constructor sets initial values of policies or sets empty values in case of unauthorized state
+     */
+    private BbdAppPolicyModel() {
+        Log.d(tag, "+ ApplicationPolicyModel()");
+        gdAndroid = GDAndroid.getInstance();
+        try {
+            appPolicyMap = gdAndroid.getApplicationPolicy();
+        } catch (GDNotAuthorizedError e) {
+            Log.d(tag, "GDNotAuthorizedError " + e.getMessage());
+            appPolicyMap = new HashMap<String, Object>();
+        }
+    }
+
+    /**
+     * @return return single shared instance of class
+     */
+    public static synchronized BbdAppPolicyModel getInstance() {
+        if (instance == null) {
+            instance = new BbdAppPolicyModel();
+        }
+        return instance;
+    }
+
+    /**
+     * The updatePolicy method updates model with new values of application policy by the
+     * BlackBerry Dynamics Runtime calls and notifies observers about changes
+     */
+    public void updateAppPolicy() {
+        Log.d(tag, "+ updateAppPolicy()");
+        synchronized (this) {
+            try {
+                appPolicyMap = gdAndroid.getApplicationPolicy();
+            } catch (GDNotAuthorizedError e) {
+                Log.d(tag, "GDNotAuthorizedError " + e.getMessage());
+                // Set empty values in case of unauthorized state
+                appPolicyMap = new HashMap<String, Object>();
+            }
+
+        }
+
+        setChanged();
+        notifyObservers();
+        Log.d(tag, "- updateAppPolicy()");
+    }
+
+    /**
+     * @return a collection of application-specific policy settings
+     */
+    public synchronized Map<String, Object> getAppPolicyMap() {
+        return appPolicyMap;
+    }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdRNApplicationModule.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdRNApplicationModule.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackberry.bbd.reactnative.application;
+
+import static com.blackberry.bbd.reactnative.helpers.RNBbdServiceHelper.convertJsonToMap;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.good.gd.GDAndroid;
+import com.good.gd.GDAppServer;
+import com.good.gd.error.GDNotAuthorizedError;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.util.List;
+import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+
+public class BbdRNApplicationModule extends ReactContextBaseJavaModule {
+
+  static final String MODULE_NAME = "BbdRNApplication";
+  private final ReactApplicationContext reactContext;
+
+  private GDAndroid gdAndroid = GDAndroid.getInstance();
+
+  public BbdRNApplicationModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.reactContext = reactContext;
+  }
+
+  @Override
+  public String getName() {
+    return MODULE_NAME;
+  }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+    // DEVNOTE: keep it, as it's required for Event Emitter calls starting from 0.65 RN
+    // Set up any upstream listeners or background tasks as necessary
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // DEVNOTE: keep it, as it's required for Event Emitter calls starting from 0.65 RN
+    // Remove upstream listeners, stop unnecessary background tasks
+  }
+
+  @ReactMethod
+  public void getApplicationConfig(final Promise promise) {
+    gdAndroid.setGDAppEventListener(new BbdAppEventListener());
+
+    BbdAppConfigModel.getInstance().addObserver(new Observer() {
+      @Override
+      public void update(final Observable observable, final Object object) {
+        if (observable == BbdAppConfigModel.getInstance()) {
+          if (reactContext != null) {
+            try {
+              final WritableMap appConfig =  parseAppConfig();
+              reactContext
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("onAppConfigUpdate", appConfig);
+            } catch (JSONException e) {
+              reactContext
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("onError", "ERROR: issue occured with serializing data.");
+            }
+          }
+        }
+      }
+    });
+
+    try {
+      final WritableMap appConfig = parseAppConfig();
+      promise.resolve(appConfig);
+    } catch (final GDNotAuthorizedError | JSONException e) {
+      promise.reject(this.getName(), e.getMessage());
+    }
+  }
+
+  @ReactMethod
+  public void getApplicationPolicy(final Promise promise) {
+    gdAndroid.setGDAppEventListener(new BbdAppEventListener());
+
+    BbdAppPolicyModel.getInstance().addObserver(new Observer() {
+      @Override
+      public void update(final Observable observable, final Object object) {
+        if (observable == BbdAppPolicyModel.getInstance()) {
+          if (reactContext != null) {
+            try {
+              final WritableMap appPolicy = parseAppPolicy();
+              reactContext
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("onAppPolicyUpdate", appPolicy);
+            } catch (JSONException e) {
+              reactContext
+                  .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                  .emit("onError", "ERROR: issue occured with serializing data.");
+            }
+          }
+        }
+      }
+    });
+
+    try {
+      final WritableMap appPolicy = parseAppPolicy();
+      promise.resolve(appPolicy);
+    } catch (final GDNotAuthorizedError | JSONException e) {
+      promise.reject(this.getName(), e.getMessage());
+    }
+  }
+
+  private WritableMap parseAppConfig() throws JSONException {
+    Map<String, Object> applicationConfig;
+    applicationConfig = BbdAppConfigModel.getInstance().getAppConfigMap();
+
+    final JSONObject result = new JSONObject();
+
+    for (final String key : applicationConfig.keySet()) {
+      Object value = applicationConfig.get(key);
+
+      if (GDAndroid.GDAppConfigKeyServers.equals(key)) {
+        value = parseGDAppServers(value);
+      }
+
+      if (GDAndroid.GDAppConfigKeyEnterpriseIdFeatures.equals(key)) {
+        value = parseEnterpriseIdFeatures(value);
+      }
+
+      if (GDAndroid.GDAppConfigKeyExtraInfo.equals(key) ||
+              GDAndroid.GDAppConfigKeyCommunicationProtocols.equals(key)) {
+        value = new JSONObject(value.toString());
+      }
+
+      result.put(key, value);
+    }
+    return convertJsonToMap(result);
+  }
+
+  private WritableMap parseAppPolicy() throws JSONException {
+    final Map<String, Object> appPolicy =  BbdAppPolicyModel.getInstance().getAppPolicyMap();
+    return convertJsonToMap(new JSONObject(appPolicy));
+  }
+
+  private String[] parseEnterpriseIdFeatures(final Object enterpriseIdFeatures) {
+    String temp = enterpriseIdFeatures.toString().substring(2);
+    temp = temp.substring(0, temp.length()-2).replace("\"", "");
+
+    return temp.split(", ");
+  }
+
+  private JSONArray parseGDAppServers(final Object serversContainer) throws JSONException {
+    /*
+     * NOTE: Since the GDAppConfigKeyServers returns a list of GDAppServer objects, this list
+     * will be formatted to conform to the following JSON fragment:
+     *    [{server:<server-name>, port:<port-number>, priority:<priority-number>}, {...} ]
+     */
+
+    final List<GDAppServer> servers = (List<GDAppServer>) serversContainer;
+
+    final JSONArray serversValue = new JSONArray();
+
+    for (final GDAppServer server : servers) {
+      final JSONObject serverObject = new JSONObject();
+
+      serverObject.put("server", server.server);
+      serverObject.put("port", server.port);
+      serverObject.put("priority", server.priority);
+
+      serversValue.put(serverObject);
+    }
+
+    return serversValue;
+  }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdRNApplicationPackage.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/android/src/main/java/com/blackberry/bbd/reactnative/application/BbdRNApplicationPackage.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.blackberry.bbd.reactnative.application;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+public class BbdRNApplicationPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Arrays.<NativeModule>asList(new BbdRNApplicationModule(reactContext));
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/index.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/index.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * @flow strict-local
+ */
+
+'use strict';
+
+import { NativeModules } from 'react-native';
+
+const { BbdRNApplication } = NativeModules;
+
+type ApplicationConfig = {
+  appHost?: ?string,
+  appPort?: ?number,
+  appServers?: ?Array<{
+    port: ?number,
+    priority: ?number,
+    server: ?string
+  }>,
+  communicationProtocols?: ?{[key: string]: boolean},
+  containerId?: ?string,
+  copyPasteOn?: ?boolean,
+  detailedLogsOn?: ?boolean,
+  enterpriseId?: ?string,
+  enterpriseIdActivated?: ?boolean,
+  enterpriseIdFeatures?: ?Array<string>,
+  extraInfo?: ?{[key: string]: string},
+  keyboardRestrictedMode?: ?boolean,
+  preventAndroidDictation?: ?boolean,
+  preventDictation?: ?boolean,
+  preventKeyboardExtensions?: ?boolean,
+  preventPasteFromNonGDApps?: ?boolean,
+  preventScreenCapture?: ?boolean,
+  preventUserDetailedLogs?: ?boolean,
+  preventCustomKeyboards?: ?boolean,
+  preventScreenRecording?: ?boolean,
+  protectedByPassword?: ?boolean,
+  upn?: ?string,
+  userId?: ?string
+};
+
+class Application {
+  constructor() { }
+
+  getApplicationConfig(): Promise<ApplicationConfig> {
+    return BbdRNApplication.getApplicationConfig();
+  }
+
+  getApplicationPolicy(): Promise<{[key: string]: any}> {
+    return BbdRNApplication.getApplicationPolicy();
+  }
+
+}
+
+export default new Application();

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.podspec
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.podspec
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Pod::Spec.new do |s|
+  s.name         = "BbdRNApplication"
+  s.version      = "1.0.0"
+  s.summary      = "BbdRNApplication"
+  s.homepage     = "https://developers.blackberry.com/"
+  s.license      = { :type => "Apache License, Version 2.0" }
+  s.author       = {
+    "Volodymyr Taliar" => "vtaliar@blackberry.com",
+    "Taras Omelchuk" => "tomelchuk@blackberry.com",
+    "Bohdan Pidluzhnyy" => "bpidluzhnyy@blackberry.com"
+  }
+  s.platform     = :ios, "9.0"
+  s.source       = {
+    :git => "https://github.com/blackberry/BlackBerry-Dynamics-React-Native-SDK.git",
+    :tag => "#{s.version}"
+  }
+  s.source_files = "BbdRNApplication/**/*.{h,m}"
+  s.requires_arc = true
+  s.dependency "React"
+  s.dependency "BlackBerryDynamics"
+end

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.xcodeproj/project.pbxproj
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.xcodeproj/project.pbxproj
@@ -1,0 +1,259 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B3E7B58A1CC2AC0600A0062D /* BbdRNApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* BbdRNApplication.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libBbdRNApplication.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBbdRNApplication.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B3E7B5881CC2AC0600A0062D /* BbdRNApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BbdRNApplication.h; sourceTree = "<group>"; };
+		B3E7B5891CC2AC0600A0062D /* BbdRNApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BbdRNApplication.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libBbdRNApplication.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				B3E7B5881CC2AC0600A0062D /* BbdRNApplication.h */,
+				B3E7B5891CC2AC0600A0062D /* BbdRNApplication.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* BbdRNApplication */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "BbdRNApplication" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BbdRNApplication;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libBbdRNApplication.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0830;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "BbdRNApplication" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				58B511DA1A9E6C8500147676 /* BbdRNApplication */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3E7B58A1CC2AC0600A0062D /* BbdRNApplication.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+				"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = BbdRNApplication;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = BbdRNApplication;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "BbdRNApplication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "BbdRNApplication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.xcworkspace/contents.xcworkspacedata
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,9 @@
+// !$*UTF8*$!
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BbdRNApplication.xcodeproj">
+   </FileRef>
+</Workspace>
+  

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication/BbdRNApplication.h
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication/BbdRNApplication.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if __has_include("RCTBridgeModule.h")
+#import "RCTBridgeModule.h"
+#else
+#import <React/RCTBridgeModule.h>
+#endif
+#import <React/RCTEventEmitter.h>
+
+@interface BbdRNApplication : RCTEventEmitter <RCTBridgeModule>
+
+@end

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication/BbdRNApplication.m
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/ios/BbdRNApplication/BbdRNApplication.m
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "BbdRNApplication.h"
+#import <BlackBerryDynamics/GD/GDAppServer.h>
+#import <BlackBerryDynamics/GD/GDServiceProvider.h>
+#import <BlackBerryDynamics/GD/GDServices.h>
+#import <BlackBerryDynamics/GD/GDiOS.h>
+
+static NSString *kAppServerServerKey = @"server";
+static NSString *kAppServerPortKey = @"port";
+static NSString *kAppServerPriorityKey = @"priority";
+
+@interface AppConfig : NSObject
+
+@property (strong, nonatomic) NSDictionary *appConfig;
+
++(AppConfig *)sharedInstance;
+-(void)setAppConfigFromRuntime;
+
+@end
+
+@implementation AppConfig
+
++(AppConfig *)sharedInstance
+{
+    static AppConfig *sharedInstance = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        sharedInstance = [[AppConfig alloc] init];
+    });
+    return sharedInstance;
+}
+
+-(void)setAppConfigFromRuntime
+{
+    GDiOS *gdRuntime = [GDiOS sharedInstance];
+    self.appConfig = [gdRuntime getApplicationConfig];
+}
+
+@end
+
+@interface AppPolicy : NSObject
+
+@property (strong, nonatomic) NSDictionary *appPolicy;
+
++(AppPolicy *)sharedInstance;
+-(void)setAppPolicyFromRuntime;
+
+@end
+
+@implementation AppPolicy
+
++(AppPolicy *)sharedInstance
+{
+    static AppPolicy *sharedInstance = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        sharedInstance = [[AppPolicy alloc] init];
+    });
+    return sharedInstance;
+}
+
+-(void)setAppPolicyFromRuntime
+{
+    GDiOS *gdRuntime = [GDiOS sharedInstance];
+    //we can set application specific policy by uploading specific xml file on enterprise
+    // management console for the application
+
+    // this is application specific policy as NSDictionary that comes from UEM
+    self.appPolicy = [gdRuntime getApplicationPolicy];
+}
+
+@end
+
+@implementation BbdRNApplication
+{
+    bool hasListeners;
+}
+
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
+
+RCT_EXPORT_MODULE()
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didRecieveStateChange:)
+                                                     name:GDStateChangeNotification
+                                                   object:nil];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didRecieveAppPolicyUpdate:)
+                                                     name:GDPolicyUpdateNotification
+                                                   object:nil];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didRecieveRemoteSettingsUpdate:)
+                                                     name:GDRemoteSettingsUpdateNotification
+                                                   object:nil];
+    }
+    return self;
+}
+
+#pragma mark Emitter
+-(NSArray*)supportedEvents
+{
+    return @[@"onAppPolicyUpdate", @"onAppConfigUpdate", @"onError"];
+}
+
+// Will be called when this module's first listener is added.
+-(void)startObserving
+{
+    hasListeners = YES;
+}
+
+// Will be called when this module's last listener is removed, or on dealloc.
+-(void)stopObserving
+{
+    hasListeners = NO;
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+-(void)didRecieveAppPolicyUpdate:(NSNotification *)notification
+{
+    if ([notification.name isEqualToString:GDPolicyUpdateNotification])
+    {
+        AppPolicy *policyObj = [AppPolicy sharedInstance];
+        [policyObj setAppPolicyFromRuntime];
+
+        [self sendEventWithName:@"onAppPolicyUpdate" body:policyObj.appPolicy];
+    }
+}
+
+-(void)didRecieveRemoteSettingsUpdate:(NSNotification *)notification
+{
+    if ([notification.name isEqualToString:GDRemoteSettingsUpdateNotification])
+    {
+        NSError* error = nil;
+        NSDictionary* config = [self parseAppConfig:error];
+
+        if(error)
+        {
+            [self sendEventWithName:@"onError" body:error.description];
+        }
+
+        [self sendEventWithName:@"onAppConfigUpdate" body:config];
+    }
+}
+
+-(void)didRecieveStateChange:(NSNotification *)notification
+{
+    if ([[notification name] isEqualToString:GDStateChangeNotification])
+    {
+        NSDictionary *userInfo = [notification userInfo];
+        NSString *propertyName = [userInfo objectForKey:GDStateChangeKeyProperty];
+        if ([propertyName isEqualToString:GDKeyIsAuthorized])
+        {
+            [[NSNotificationCenter defaultCenter] postNotificationName:GDPolicyUpdateNotification
+                                                                object:self];
+
+            [[NSNotificationCenter defaultCenter] postNotificationName:GDRemoteSettingsUpdateNotification
+                                                                object:self];
+        }
+    }
+}
+
+-(NSDictionary*)parseAppConfig:(NSError *)error
+{
+    /*
+     * NOTE: Since the GDAppConfigKeyServers returns a list of GDAppServer objects, this list
+     * will be formatted to conform to the following JSON fragment:
+     *        [{server:<server-name>, port:<port-number>, priority:<priority-number>}, {...} ]
+     */
+
+    AppConfig *appConfig = [AppConfig sharedInstance];
+    [appConfig setAppConfigFromRuntime];
+
+    NSMutableDictionary* config = [appConfig.appConfig mutableCopy];
+
+    NSArray *appServers = [config objectForKey:GDAppConfigKeyServers];
+
+    if (appServers && ![appServers isKindOfClass:[NSNull class]] && appServers.count > 0)
+    {
+        NSArray *appServersToSet = [self getAppServersAsDictionariesArray:appServers];
+
+        [config setObject:appServersToSet forKey:GDAppConfigKeyServers];
+    }
+    else
+    {
+        [config setObject:[NSArray array] forKey:GDAppConfigKeyServers];
+    }
+
+    NSString *enterpriseIdFeaturesString = [config objectForKey:GDAppConfigKeyEnterpriseIdFeatures];
+    NSString *temp = [enterpriseIdFeaturesString substringFromIndex:2];
+    temp = [temp substringToIndex:[temp length] - 2];
+    temp = [temp stringByReplacingOccurrencesOfString:@"\"" withString:@""];
+    NSArray *enterpriseIdFeaturesArr = [temp componentsSeparatedByString:@", "];
+    if (enterpriseIdFeaturesArr && enterpriseIdFeaturesArr.count > 0)
+    {
+        [config setObject:enterpriseIdFeaturesArr forKey:GDAppConfigKeyEnterpriseIdFeatures];
+    }
+    else
+    {
+        [config setObject:[NSArray array] forKey:GDAppConfigKeyEnterpriseIdFeatures];
+    }
+
+    NSString *extraInfoString = [config objectForKey:GDAppConfigKeyExtraInfo];
+    NSData *extraInfoJsonData = [extraInfoString dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *extraInfoDict = [NSJSONSerialization JSONObjectWithData:extraInfoJsonData options:0 error:&error];
+    if (extraInfoDict)
+    {
+        [config setObject:extraInfoDict forKey:GDAppConfigKeyExtraInfo];
+    }
+    else
+    {
+        [config setObject:[NSDictionary dictionary] forKey:GDAppConfigKeyExtraInfo];
+    }
+
+    return config;
+}
+
+-(NSArray *)getAppServersAsDictionariesArray:(NSArray *)appServers
+{
+    NSMutableArray *appServersAsDictionary = [NSMutableArray array];
+
+    for (GDAppServer *appServer in appServers)
+    {
+        NSMutableDictionary *appServerAsDictionaty = [NSMutableDictionary dictionary];
+
+        [appServerAsDictionaty setValue:appServer.server forKey:kAppServerServerKey];
+        [appServerAsDictionaty setValue:appServer.port forKey:kAppServerPortKey];
+        [appServerAsDictionaty setValue:appServer.priority forKey:kAppServerPriorityKey];
+
+        [appServersAsDictionary addObject:appServerAsDictionaty];
+    }
+
+    return appServersAsDictionary;
+}
+
+#pragma mark GetApplicationConfig
+RCT_EXPORT_METHOD(getApplicationConfig:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSError* error = nil;
+    NSDictionary* config = [self parseAppConfig:error];
+
+    if(!error)
+    {
+        resolve(config);
+        return;
+    }
+
+    NSString* message = error == nil ? @"ERROR: issue occured with serializing data." : error.debugDescription;
+    reject(nil, message, error);
+}
+
+#pragma mark GetApplicationPolicy
+RCT_EXPORT_METHOD(getApplicationPolicy:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    AppPolicy *policyObj = [AppPolicy sharedInstance];
+    [policyObj setAppPolicyFromRuntime];
+
+    resolve(policyObj.appPolicy);
+}
+
+@end

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/package.json
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/package.json
@@ -1,0 +1,18 @@
+
+{
+  "name": "BlackBerry-Dynamics-for-React-Native-Application",
+  "version": "1.0.0",
+  "description": "BlackBerry Dynamics Application module provides access to information that is globally available to any BlackBerry Dynamics Application.",
+  "main": "index.js",
+  "scripts": {
+    "install": "node ./scripts/install_hook.js",
+    "flow": "flow"
+  },
+  "keywords": [
+    "react-native"
+  ],
+  "license": "SEE LICENSE IN LICENSE",
+  "devDependencies": {
+    "flow-bin": "^0.98.0"
+  }
+}

--- a/modules/BlackBerry-Dynamics-for-React-Native-Application/scripts/install_hook.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Application/scripts/install_hook.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function() {
+  checkAndExitOrContinue();
+
+  const execSync = require('child_process').execSync,
+    path = require('path'),
+    projectRoot = process.env.INIT_CWD,
+    scriptPath = path.join(
+      projectRoot, 'node_modules', 'BlackBerry-Dynamics-for-React-Native-Base',
+      'scripts', 'react_native_info', 'update_development_info.js'
+    );
+
+  try {
+    execSync(`node "${scriptPath}"`);
+  } catch (e) {
+    // BlackBerry-Dynamics-for-React-Native-Base is not yet installed.
+    // We shouldn't do any actions here.
+  }
+
+  function checkAndExitOrContinue() {
+    var originalNpmConfigArgv = JSON.parse(process.env.npm_config_argv).original,
+      filteredOriginal = originalNpmConfigArgv.filter(function(val, i) {
+        return !['--save', '--verbose', '--d'].includes(val);
+      });
+
+    if (!(filteredOriginal[1] && filteredOriginal[1].indexOf('BlackBerry-Dynamics-for-React-Native-Application') > -1 &&
+      (filteredOriginal.includes('i') || filteredOriginal.includes('install') || filteredOriginal.includes('add')))) {
+      process.exit(0);
+    }
+  }
+
+})();

--- a/modules/BlackBerry-Dynamics-for-React-Native-Async-Storage/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Async-Storage/README.md
@@ -5,10 +5,11 @@ The JavaScript API of this module remains the same but file(s) that contain Asyn
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-Async-Storage` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/modules/BlackBerry-Dynamics-for-React-Native-Async-Storage/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Async-Storage/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  * Some modifications to the original @react-native-community/async-storage
  * from https://github.com/react-native-community/async-storage/
  */
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/README.md
@@ -9,10 +9,11 @@ Please setup your environment as described in the [React Native documentation](h
 ## Supportability
 
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 
@@ -23,13 +24,35 @@ Please setup your environment as described in the [React Native documentation](h
 
 #### Dynamics SDK Dependency
 
-Dynamics SDK for iOS and Android are now installed as part of the Base plugin using CocoaPods & Gradle. The integration uses the iOS "Dynamic Framework" version of BlackBerry Dynamics as the static library is no longer supported.
+Dynamics SDK for iOS and Android are now installed as part of the Base module using CocoaPods & Gradle. The integration uses the iOS "Dynamic Framework" version of BlackBerry Dynamics as the static library is no longer supported.
+
+##### BlackBerry Dynamics SDK for iOS integration
+###### Using latest released version - default
+By default, `BlackBerry-Dynamics-for-React-Native-Base` module will integrate **latest** available BlackBerry Dynamics SDK for iOS using following podspec: `https://software.download.blackberry.com/repository/framework/dynamics/ios/10.2.0.83/BlackBerryDynamics-10.2.0.83.podspec`.
+> NOTE: If one of the below integration methods was used there is an option to reset **default** configuration by running following command:
+`$ yarn set-dynamics-podspec --default`
+`$ cd ios && pod install && cd ..`
+
+###### Using other released version
+There is possibility to integrate other released build of BlackBerry Dynamics SDK for iOS.
+Following command should be run:
+```
+$ yarn set-dynamics-podspec --url "https://software.download.blackberry.com/repository/framework/dynamics/ios/10.1.0.36/BlackBerryDynamics-10.1.0.36.podspec"
+$ cd ios && pod install && cd ..
+```
+###### Using locally downloaded version
+Also, it is possible to integrate manually downloaded BlackBerry Dynamics SDK for iOS from local place.
+Following command should be run:
+```
+$ yarn set-dynamics-podspec --path "/Users/<user>/Downloads/gdsdk-release-dylib-X.X.X.X/BlackBerry_Dynamics_SDK_for_iOS_vX.X.X.X_dylib"
+$ cd ios && pod install && cd ..
+```
 
 ## Installation
 
 #### react-native
 
-    $ react-native init <appFolder> --version 0.64.0
+    $ react-native init <appFolder> --version 0.66.0
     $ cd <appFolder>
     $ yarn add <path>/modules/BlackBerry-Dynamics-for-React-Native-Base
 
@@ -41,10 +64,10 @@ Dynamics SDK for iOS and Android are now installed as part of the Base plugin us
 
 ##### iOS
 
-$ cd ios
-$ pod install
-$ cd ..
-$ react-native run-ios
+    $ cd ios  
+    $ pod install  
+    $ cd ..  
+    $ react-native run-ios  
 
 ##### Android
 

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ apply plugin: "com.android.library"
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/android/gd.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/android/gd.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/android/helper.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/android/helper.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 
 ext {
     getBbdMavenLocation = 'https://software.download.blackberry.com/repository/maven'
-    minSdkVersion = 26
+    minSdkVersion = 28
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/package.json
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/package.json
@@ -1,11 +1,13 @@
 {
   "name": "BlackBerry-Dynamics-for-React-Native-Base",
   "version": "1.0.0",
+  "dynamicsPodSpec":"https://software.download.blackberry.com/repository/framework/dynamics/ios/BlackBerryDynamics.podspec",
   "description": "This is a BlackBerry Dynamics Base module for React Native that automatically integrates the BlackBerry Dynamics SDK for iOS and Android into a React Native application",
   "main": "index.js",
   "bin": {
     "set-bundle-id": "./scripts/bbd_rn_rename_cli.js",
-    "set-port-8082": "./scripts/bbd_rn_port_8082.js"
+    "set-port-8082": "./scripts/bbd_rn_port_8082.js",
+    "set-dynamics-podspec": "./scripts/setDynamicsPod.js"
   },
   "scripts": {
     "install": "node ./scripts/bbd_rn_install.js",

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/BlackBerryDynamics.podspec
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/BlackBerryDynamics.podspec
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Pod::Spec.new do |spec|
+  spec.name                = 'BlackBerryDynamics'
+  spec.version             = '1.0.0'
+  spec.homepage            = 'https://developers.blackberry.com'
+  spec.license             = { :type => 'Commercial', :file => 'license.txt' }
+  spec.author              = 'BlackBerry'
+  spec.summary             = 'BlackBerry Dynamics secure application container management'
+  spec.description         = <<-DESC
+                          Framework for building secure enterprise applications managed by BlackBerry Unified Endpoint Management (UEM).
+                          DESC
+  spec.platform            = :ios, '13.0'
+  spec.source              = { :git => "", :tag => "#{spec.version}" }
+  spec.requires_arc        = true
+  spec.swift_version       = '5.0'
+
+  spec.subspec 'BlackBerryDynamics' do |core|
+    core.preserve_paths      = 'Frameworks/BlackBerryDynamics.xcframework', 'Frameworks/BlackBerryCerticom.xcframework', 'Frameworks/BlackBerryCerticomSBGSE.xcframework', 'license.txt'
+    core.vendored_frameworks = 'Frameworks/BlackBerryDynamics.xcframework', 'Frameworks/BlackBerryCerticom.xcframework', 'Frameworks/BlackBerryCerticomSBGSE.xcframework'
+  end
+end

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/ReactNativeHelper.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/ReactNativeHelper.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class ReactNativeHelper {
       return beforePostInstall + content + afterPostInstall;
     };
 
-    podfileContent = podfileContent.replace(constants.podPlatformPatternVersion, constants.podPlatformV13);
+    podfileContent = podfileContent.replace(constants.podPlatformPatternVersion, constants.podPlatformVersion);
 
     if (!podfileContent.includes(constants.disabledFlipper)) {
       podfileContent = podfileContent.replace(constants.enabledFlipper, constants.disabledFlipper);

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/bbd_rn_cleanup.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/bbd_rn_cleanup.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,12 +54,14 @@
   function removeUpdatePodsFromPodfile() {
     var projectRoot = process.env.INIT_CWD,
       podfilePath = path.join(projectRoot, 'ios', 'Podfile'),
-      podfileContent = fs.readFileSync(podfilePath, 'utf-8'),
-      newPodfileContent = podfileContent.replace(constants.updatePodsCommand, ''),
-      newPodfileContent = newPodfileContent.replace(constants.bbdPodCommand, '');
-      newPodfileContent = newPodfileContent.replace(constants.disabledFlipper, constants.enabledFlipper);
+      podfileContent = fs.readFileSync(podfilePath, 'utf-8');
 
-    fs.writeFileSync(podfilePath, newPodfileContent, 'utf-8');
+    podfileContent = podfileContent
+      .replace(constants.updatePodsCommand, '')
+      .replace(constants.bbdPodTemplate, '')
+      .replace(constants.disabledFlipper, constants.enabledFlipper);
+
+    fs.writeFileSync(podfilePath, podfileContent, 'utf-8');
   }
 
 })();

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/bbd_rn_cleanup_android.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/bbd_rn_cleanup_android.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@
   var fs = require('fs'),
     path = require('path'),
     projectRoot = process.env.INIT_CWD,
-    androidProjectRoot = path.join(projectRoot, 'android');
+    androidProjectRoot = path.join(projectRoot, 'android'),
+    constants = require('./constants');
 
   if (fs.existsSync(androidProjectRoot)) {
     // Cleanup root build.gradle
@@ -53,12 +54,19 @@
 
     var bbdLifeCycleCall = '\n\t\tBBDLifeCycle.getInstance().initialize(this);\n',
       bbdLifeCycleImport = '\nimport com.blackberry.bbd.reactnative.core.BBDLifeCycle;\n',
+      bbdReactActivityDelegateImport = '\nimport com.blackberry.bbd.reactnative.core.BBDReactActivityDelegate;\n',
       bbdReactActivityImport = '\nimport com.blackberry.bbd.reactnative.core.BBDReactActivity;\n';
 
     fs.writeFileSync(
       projectMainActivityPath,
-      removeImportLineInJavaFile(bbdReactActivityImport,
-        updateExtendsClassInMainActivity(projectMainActivityContent)
+      removeImportLineInJavaFile(bbdReactActivityDelegateImport,
+        removeImportLineInJavaFile(bbdReactActivityImport,
+          updateReactActivityDelegateUsage(
+            updateReactActivityUsage(
+              updateExtendsClassInMainActivity(projectMainActivityContent)
+            )
+          )
+        )
       )
     );
     fs.writeFileSync(
@@ -101,7 +109,15 @@
     });
 
     function updateExtendsClassInMainActivity(fileContent) {
-      return fileContent.replace('extends BBDReactActivity', 'extends ReactActivity');
+      return fileContent.replace(/extends BBDReactActivity/gi, 'extends ReactActivity');
+    }
+
+    function updateReactActivityDelegateUsage(fileContent) {
+      return fileContent.replace(/ BBDReactActivityDelegate/gi, ' ReactActivityDelegate');
+    }
+
+    function updateReactActivityUsage(fileContent) {
+      return fileContent.replace('BBDReactActivity activity', 'ReactActivity activity');
     }
 
     function updateOnCreateInMainApplication(fileContent) {

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/constants.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/constants.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ const updatePodsCommand = '\t\tsystem("node ../node_modules/BlackBerry-Dynamics-
   '/scripts/updatePods.js")\n';
 
 const podPlatformPatternVersion = /platform :ios, '([0-9\.]+)'/;
-const podPlatformV13 = 'platform :ios, \'13.0\'';
+const podPlatformVersion = 'platform :ios, \'14.0\'';
 
 const bbdPodCommand = 'pod \'BlackBerryDynamics\', ' +
-  ':podspec => \'https://software.download.blackberry.com/repository/framework/dynamics/ios/BlackBerryDynamics.podspec\'\n';
+  ':podspec => \'https://software.download.blackberry.com/repository/framework/dynamics/ios/10.2.0.83/BlackBerryDynamics-10.2.0.83.podspec\'\n';
+
+const bbdPodTemplate = /pod 'BlackBerryDynamics', (:podspec|:path) => '(.+)'/;
 
 const enabledFlipper = '  use_flipper!()';
 
@@ -34,8 +36,9 @@ const disabledFlipper = '  #\n' +
 module.exports = {
   updatePodsCommand,
   bbdPodCommand,
+  bbdPodTemplate,
   podPlatformPatternVersion,
-  podPlatformV13,
+  podPlatformVersion,
   enabledFlipper,
   disabledFlipper
 };

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/custom_rn_rename/bundleIdentifiers.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/custom_rn_rename/bundleIdentifiers.js
@@ -1,10 +1,12 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  * Some modifications to the original react-native-rename
  * from https://github.com/junedomingo/react-native-rename/
  */
 
 'use strict';
+
+var path = require('path');
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -15,14 +17,25 @@ exports.bundleIdentifiers = bundleIdentifiers;
 
 function bundleIdentifiers(currentAppName, newName, projectName, currentBundleID, newBundleID, newBundlePath) {
   var nS_CurrentAppName = currentAppName.replace(/\s/g, '');
+  var newArchitecturePath = path.join(newBundlePath, 'newarchitecture');
   var listOfRegExpReplacements = [{
-    regex: currentBundleID,
+    regex: new RegExp(currentBundleID, 'g'),
     replacement: newBundleID,
-    paths: ['android/app/BUCK', 'android/app/build.gradle', 'android/app/src/main/AndroidManifest.xml']
+    paths: [
+      path.join('android', 'app', 'BUCK'),
+      path.join('android', 'app', 'build.gradle'),
+      path.join('android', 'app', 'src', 'main', 'AndroidManifest.xml'),
+      path.join(newBundlePath, 'MainApplication.java')
+    ]
   }, {
-    regex: new RegExp('^package[ \t]+' + currentBundleID, 'm'),
-    replacement: 'package ' + newBundleID,
-    paths: [newBundlePath + '/MainActivity.java', newBundlePath + '/MainApplication.java']
+    regex: new RegExp('^(package|import)[ \t]+' + currentBundleID, 'gm'),
+    replacement: '$1 ' + newBundleID,
+    paths: [
+      path.join(newBundlePath, 'MainActivity.java'),
+      path.join(newArchitecturePath, 'MainApplicationReactNativeHost.java'),
+      path.join(newArchitecturePath, 'components', 'MainComponentsRegistry.java'),
+      path.join(newArchitecturePath, 'modules', 'MainApplicationTurboModuleManagerDelegate.java')
+    ]
   }];
 
   if (newName) {
@@ -34,7 +47,7 @@ function bundleIdentifiers(currentAppName, newName, projectName, currentBundleID
       // replaced by an update to the app name with the same bundle ID
       regex: new RegExp('(?!\\.)(.|^)' + nS_CurrentAppName, 'g'),
       replacement: '$1' + nS_NewName,
-      paths: [newBundlePath + '/MainActivity.java']
+      paths: [path.join(newBundlePath, 'MainActivity.java')]
     };
     listOfRegExpReplacements.push(newNameRegExpReplacement);
   }

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/react_native_info/development-tools-info.json
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/react_native_info/development-tools-info.json
@@ -1,7 +1,7 @@
 {
   "framework": {
     "name": "ReactNative",
-    "bbdSdkForReactNativeVersion": "10.0.0.6",
+    "bbdSdkForReactNativeVersion": "10.1.0.9",
     "react-native": "",
     "react": "",
     "system": {

--- a/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/setDynamicsPod.js
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Base/scripts/setDynamicsPod.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function (argv) {
+   const fse = require('fs-extra'),
+      path = require('path'),
+      isWindows = process.platform === 'win32',
+      projectRoot = process.env.PWD || process.env.INIT_CWD || process.cwd(),
+      bbdBasePath = path.join(projectRoot, 'node_modules', 'BlackBerry-Dynamics-for-React-Native-Base'),
+      { dynamicsPodSpec } = require(path.join(bbdBasePath, 'package.json')),
+      pattern = /pod 'BlackBerryDynamics', (:podspec|:path) => '(.+)'/;
+
+   if (isWindows) return;
+
+   const parce = (arg, options = { value: null }) => {
+      const argument = {
+         index: null,
+         value: null
+      };
+
+      argument.index = argv.indexOf(arg);
+      if (argument.index > -1) {
+         argument.value = options.value ? options.value : argv[argument.index + 1];
+      }
+
+      return argument.value;
+   };
+
+   const copyPodspecFile = (_path) => {
+      const specPath = path.join(_path, 'BlackBerryDynamics.podspec');
+      if (fse.existsSync(specPath))
+         return;
+      const pathToInnerSpec = path.join(bbdBasePath, 'scripts', 'BlackBerryDynamics.podspec');
+      fse.copyFileSync(pathToInnerSpec, specPath);
+   }
+
+   const setPodVersion = (_path) => {
+      const specPath = path.join(_path, 'BlackBerryDynamics.podspec');
+      const defaultVersion = '1.0.0';
+      const match = /([\d]+\.[\d]+\.[\d]+\.[\d]+)/.exec(_path);
+      const version = match ?  match[0] : defaultVersion;
+
+      let content = fse.readFileSync(specPath, { encoding: 'utf-8' });
+      content = content.replace(defaultVersion, version);
+
+      fse.writeFileSync(specPath, content, { encoding: 'utf-8' });
+   }
+
+   const pod = {
+      path: parce('--path'),
+      url: parce('--url'),
+      default: parce('--default', { value: true })
+   }
+
+   let spec;
+   if (pod.default) {
+      spec = `pod 'BlackBerryDynamics', :podspec => '${dynamicsPodSpec}'`;
+   }
+   if (pod.path) {
+      copyPodspecFile(pod.path);
+      setPodVersion(pod.path);
+
+      pod.path = path.join(pod.path, 'BlackBerryDynamics.podspec');
+
+      spec = `pod 'BlackBerryDynamics', :path => '${pod.path}'`;
+   }
+   if (pod.url) {
+      spec = `pod 'BlackBerryDynamics', :podspec => '${pod.url}'`;
+   }
+
+   const rootPodFilePath = path.resolve('ios', 'Podfile');
+   let rootPodFileContext = fse.readFileSync(rootPodFilePath, { encoding: 'utf-8' });
+   rootPodFileContext = rootPodFileContext.replace(pattern, spec);
+
+   fse.writeFileSync(rootPodFilePath, rootPodFileContext, { encoding: 'utf-8' });
+
+   console.log('\x1b[32m%s\x1b[0m', 'BlackBerryDynamics podspec in Podfile was successfully updated.');
+})(process.argv);

--- a/modules/BlackBerry-Dynamics-for-React-Native-Clipboard/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Clipboard/README.md
@@ -6,10 +6,11 @@ Clipboard API works in combination with Data Leakage Prevention (DLP). More deta
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-Clipboard` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/modules/BlackBerry-Dynamics-for-React-Native-Clipboard/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Clipboard/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
 }

--- a/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/README.md
@@ -5,10 +5,11 @@ The JavaScript API of this module remains the same but files/directories are sto
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 

--- a/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Networking')
     implementation "com.facebook.react:react-native:+"

--- a/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/android/src/main/java/com/blackberry/bbd/reactnative/filesystem/BbdRNFileSystemModule.java
+++ b/modules/BlackBerry-Dynamics-for-React-Native-FileSystem/android/src/main/java/com/blackberry/bbd/reactnative/filesystem/BbdRNFileSystemModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -878,6 +878,10 @@ public class BbdRNFileSystemModule extends ReactContextBaseJavaModule {
             infoMap.putInt("jobId", jobId);
             infoMap.putInt("statusCode", res.statusCode);
             infoMap.putDouble("bytesWritten", (double)res.bytesWritten);
+
+            if (res.bytesWritten == 0 && destFile.exists()) {
+              destFile.delete();
+            }
 
             promise.resolve(infoMap);
           } else {

--- a/modules/BlackBerry-Dynamics-for-React-Native-Launcher/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Launcher/README.md
@@ -5,14 +5,15 @@ For more details please refer to [Dynamics Launcher library on Android](https://
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 #### BlackBerry Dynamics Launcher library for iOS
- - 3.3.0.303
+ - 3.4.0.324
 #### BlackBerry Dynamics Launcher library for Android
- - 3.3.0.215
+ - 3.4.0.228
 
 ## Preconditions
 #### Install Base module

--- a/modules/BlackBerry-Dynamics-for-React-Native-Launcher/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Launcher/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,16 @@ apply plugin: 'com.android.library'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
 
         flatDir {
@@ -48,8 +47,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
 

--- a/modules/BlackBerry-Dynamics-for-React-Native-Networking/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Networking/README.md
@@ -21,10 +21,11 @@ The JavaScript API remains unchanged.
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-Networking` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/modules/BlackBerry-Dynamics-for-React-Native-Networking/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-Networking/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ apply plugin: "com.android.library"
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }
@@ -34,8 +33,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
     implementation "com.squareup.okhttp3:okhttp:+"
     implementation "com.squareup.okio:okio:+"

--- a/modules/BlackBerry-Dynamics-for-React-Native-SQLite-Storage/README.md
+++ b/modules/BlackBerry-Dynamics-for-React-Native-SQLite-Storage/README.md
@@ -8,10 +8,11 @@ For more details please refer to [com.good.gd.database](https://developer.blackb
 
 ## Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-SQLite-Storage` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/modules/BlackBerry-Dynamics-for-React-Native-SQLite-Storage/android/build.gradle
+++ b/modules/BlackBerry-Dynamics-for-React-Native-SQLite-Storage/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
     implementation "com.facebook.react:react-native:+"
 }

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/README.md
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/README.md
@@ -5,10 +5,11 @@
 
 # Supportability
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-Text` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/android/build.gradle
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
    	implementation "com.facebook.react:react-native:+"
 }

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/js/Text.android.js
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/js/Text.android.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  * Some modifications to the original Text UI component for react-native
  * from https://github.com/facebook/react-native/blob/0.61-stable/Libraries/Text/Text.js
  *
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const DeprecatedTextPropTypes = require('react-native/Libraries/DeprecatedPropTypes/DeprecatedTextPropTypes');
+const DeprecatedTextPropTypes = require('deprecated-react-native-prop-types').TextPropTypes;
 const React = require('react');
 const ReactNativeViewAttributes = require('react-native/Libraries/Components/View/ReactNativeViewAttributes');
 const TextAncestor = require('react-native/Libraries/Text/TextAncestor');

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/package.json
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/package.json
@@ -14,5 +14,8 @@
   "keywords": [
     "react-native"
   ],
-  "license": "SEE LICENSE IN LICENSE"
+  "license": "SEE LICENSE IN LICENSE",
+  "dependencies": {
+    "deprecated-react-native-prop-types": "^2.2.0"
+  }
 }

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/scripts/add_bbd_text_widget.js
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/scripts/add_bbd_text_widget.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,32 +22,30 @@
     projectRoot = process.env.INIT_CWD,
     bbdTextWidgetName = 'AndroidTextBbd',
     bbdVirtualTextWidgetName = 'AndroidVirtualTextBbd',
-    rnV64Pattern = /(^0\.64\.[0-9]+)/,
-    rnVersion = require(path.join(projectRoot, 'package.json'))['dependencies']['react-native'],
-    rn61RendererImplementationsPath = path.join(projectRoot, 'node_modules', 'react-native', 'Libraries', 'Renderer', 'implementations'),
-    rn61RendererDevArr = [
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-dev.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-dev.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-dev.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-dev.js')
+    rendererImplementationsPath = path.join(projectRoot, 'node_modules', 'react-native', 'Libraries', 'Renderer', 'implementations'),
+    rendererDevArr = [
+      path.join(rendererImplementationsPath, 'ReactFabric-dev.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-dev.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-dev.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-dev.js')
     ],
-    rn61RendererOtherArr = [
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-prod.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-prod.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-profiling.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-profiling.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-prod.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-prod.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-profiling.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-profiling.js')
+    rendererOtherArr = [
+      path.join(rendererImplementationsPath, 'ReactFabric-prod.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-prod.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-profiling.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-profiling.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-prod.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-prod.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-profiling.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-profiling.js')
     ];
 
   // To enable DLP within <Text \> UI component we need to extend default list of native views
   // with following views: AndroidTextBbd, AndroidVirtualTextBbd.
   // node_modules/react-native/Libraries/Renderer/implementations/* manages default native views for RN 0.61.x and higher
 
-  if (fs.existsSync(rn61RendererImplementationsPath)) {
-    rn61RendererDevArr.forEach(function(filePath) {
+  if (fs.existsSync(rendererImplementationsPath)) {
+    rendererDevArr.forEach(function(filePath) {
       var bbdTextWidgetCode = 'type === "' + bbdTextWidgetName + '" || // Android\n\t\t',
         bbdVirtualTextWidgetCode = 'type === "' + bbdVirtualTextWidgetName + '" || // Android\n\t\t';
 
@@ -58,31 +56,17 @@
       );
     });
 
-    if (rnV64Pattern.test(rnVersion)) {
-      rn61RendererOtherArr.forEach(function(filePath) {
-        var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t',
-          bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t';
-
-        addBbdTextWidget(
-          filePath,
-          bbdTextWidgetCode + bbdVirtualTextWidgetCode,
-          '"AndroidTextInput" === JSCompiler_inline_result ||'
-        );
-      });
-
-      return;
-    }
-
-    rn61RendererOtherArr.forEach(function(filePath) {
-      var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === nextContext ||\n\t\t',
-        bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === nextContext ||\n\t\t';
+    rendererOtherArr.forEach(function(filePath) {
+      var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t',
+        bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t';
 
       addBbdTextWidget(
         filePath,
         bbdTextWidgetCode + bbdVirtualTextWidgetCode,
-        '"AndroidTextInput" === nextContext ||'
+        '"AndroidTextInput" === JSCompiler_inline_result ||'
       );
     });
+
   }
 
   function addBbdTextWidget (filePath, widget, insertBefore) {

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-Text/scripts/cleanup_add_bbd_text_widget.js
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-Text/scripts/cleanup_add_bbd_text_widget.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,53 +20,41 @@
     projectRoot = process.env.INIT_CWD,
     bbdTextWidgetName = 'AndroidTextBbd',
     bbdVirtualTextWidgetName = 'AndroidVirtualTextBbd',
-    rnV64Pattern = /(^0\.64\.[0-9]+)/,
-    rnVersion = require(path.join(projectRoot, 'package.json'))['dependencies']['react-native'],
-    rn61RendererImplementationsPath = path.join(projectRoot, 'node_modules', 'react-native', 'Libraries', 'Renderer', 'implementations'),
-    rn61RendererDevArr = [
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-dev.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-dev.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-dev.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-dev.js')
+    rendererImplementationsPath = path.join(projectRoot, 'node_modules', 'react-native', 'Libraries', 'Renderer', 'implementations'),
+    rendererDevArr = [
+      path.join(rendererImplementationsPath, 'ReactFabric-dev.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-dev.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-dev.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-dev.js')
     ],
-    rn61RendererOtherArr = [
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-prod.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-prod.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-profiling.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactFabric-profiling.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-prod.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-prod.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-profiling.fb.js'),
-      path.join(rn61RendererImplementationsPath, 'ReactNativeRenderer-profiling.js')
+    rendererOtherArr = [
+      path.join(rendererImplementationsPath, 'ReactFabric-prod.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-prod.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-profiling.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactFabric-profiling.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-prod.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-prod.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-profiling.fb.js'),
+      path.join(rendererImplementationsPath, 'ReactNativeRenderer-profiling.js')
     ];
 
   checkAndExitOrContinue();
 
-  if (fs.existsSync(rn61RendererImplementationsPath)) {
-    rn61RendererDevArr.forEach(function(filePath) {
+  if (fs.existsSync(rendererImplementationsPath)) {
+    rendererDevArr.forEach(function(filePath) {
       var bbdTextWidgetCode = 'type === "' + bbdTextWidgetName + '" || // Android\n\t\t',
         bbdVirtualTextWidgetCode = 'type === "' + bbdVirtualTextWidgetName + '" || // Android\n\t\t';
 
       cleanupBbdTextWidget(filePath, bbdTextWidgetCode + bbdVirtualTextWidgetCode);
     });
 
-    if (rnV64Pattern.test(rnVersion)) {
-      rn61RendererOtherArr.forEach(function(filePath) {
-        var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t',
-          bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t';
-
-        cleanupBbdTextWidget(filePath, bbdTextWidgetCode + bbdVirtualTextWidgetCode);
-      });
-
-      return;
-    }
-
-    rn61RendererOtherArr.forEach(function(filePath) {
-      var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === nextContext ||\n\t\t',
-        bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === nextContext ||\n\t\t';
+    rendererOtherArr.forEach(function(filePath) {
+      var bbdTextWidgetCode = '"' + bbdTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t',
+        bbdVirtualTextWidgetCode = '"' + bbdVirtualTextWidgetName + '" === JSCompiler_inline_result ||\n\t\t';
 
       cleanupBbdTextWidget(filePath, bbdTextWidgetCode + bbdVirtualTextWidgetCode);
     });
+
   }
 
   function cleanupBbdTextWidget (filePath, widget) {

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/README.md
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/README.md
@@ -3,10 +3,11 @@
 > NOTE: on iOS platform DLP is supported by default via Dynamics runtime after `BlackBerry-Dynamics-for-React-Native-Base` module is installed and linked. More details about DLP on iOS can be found [here](https://developer.blackberry.com/devzone/files/blackberry-dynamics/ios/interface_g_di_o_s.html).
 
 # Supportability
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 ## Preconditions
 `BlackBerry-Dynamics-for-React-Native-TextInput` is dependent on `BlackBerry-Dynamics-for-React-Native-Base` module.

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/android/build.gradle
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
     implementation "com.facebook.react:react-native:+"
 }

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/js/AndroidTextInputNativeComponent.js
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/js/AndroidTextInputNativeComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  * Some modifications to the original TextInput UI component for react-native
  * from https://github.com/facebook/react-native
  *
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import {ViewPropTypes as ViewProps} from 'deprecated-react-native-prop-types';
 import type {
   BubblingEventHandler,
   DirectEventHandler,
@@ -30,7 +30,6 @@ import requireNativeComponent from 'react-native/Libraries/ReactNative/requireNa
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type {TextInputNativeCommands} from 'react-native/Libraries/Components/TextInput/TextInputNativeCommands';
 import * as React from 'react';
-import AndroidTextInputViewConfig from 'react-native/Libraries/Components/TextInput/AndroidTextInputViewConfig';
 const ReactNativeViewConfigRegistry = require('react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry');
 
 export type KeyboardType =
@@ -551,11 +550,125 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['focus', 'blur', 'setTextAndSelection'],
 });
 
+export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
+  uiViewClassName: 'AndroidTextInput',
+  bubblingEventTypes: {
+    topBlur: {
+      phasedRegistrationNames: {
+        bubbled: 'onBlur',
+        captured: 'onBlurCapture',
+      },
+    },
+    topEndEditing: {
+      phasedRegistrationNames: {
+        bubbled: 'onEndEditing',
+        captured: 'onEndEditingCapture',
+      },
+    },
+    topFocus: {
+      phasedRegistrationNames: {
+        bubbled: 'onFocus',
+        captured: 'onFocusCapture',
+      },
+    },
+    topKeyPress: {
+      phasedRegistrationNames: {
+        bubbled: 'onKeyPress',
+        captured: 'onKeyPressCapture',
+      },
+    },
+    topSubmitEditing: {
+      phasedRegistrationNames: {
+        bubbled: 'onSubmitEditing',
+        captured: 'onSubmitEditingCapture',
+      },
+    },
+    topTextInput: {
+      phasedRegistrationNames: {
+        bubbled: 'onTextInput',
+        captured: 'onTextInputCapture',
+      },
+    },
+  },
+  directEventTypes: {
+    topScroll: {
+      registrationName: 'onScroll',
+    },
+  },
+  validAttributes: {
+    maxFontSizeMultiplier: true,
+    adjustsFontSizeToFit: true,
+    minimumFontScale: true,
+    autoFocus: true,
+    placeholder: true,
+    inlineImagePadding: true,
+    contextMenuHidden: true,
+    textShadowColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    maxLength: true,
+    selectTextOnFocus: true,
+    textShadowRadius: true,
+    underlineColorAndroid: {
+      process: require('react-native/Libraries/StyleSheet/processColor'),
+    },
+    textDecorationLine: true,
+    blurOnSubmit: true,
+    textAlignVertical: true,
+    fontStyle: true,
+    textShadowOffset: true,
+    selectionColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    selection: true,
+    placeholderTextColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    importantForAutofill: true,
+    lineHeight: true,
+    textTransform: true,
+    returnKeyType: true,
+    keyboardType: true,
+    multiline: true,
+    color: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    autoComplete: true,
+    numberOfLines: true,
+    letterSpacing: true,
+    returnKeyLabel: true,
+    fontSize: true,
+    onKeyPress: true,
+    cursorColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    text: true,
+    showSoftInputOnFocus: true,
+    textAlign: true,
+    autoCapitalize: true,
+    autoCorrect: true,
+    caretHidden: true,
+    secureTextEntry: true,
+    textBreakStrategy: true,
+    onScroll: true,
+    onContentSizeChange: true,
+    disableFullscreenUI: true,
+    includeFontPadding: true,
+    fontWeight: true,
+    fontFamily: true,
+    allowFontScaling: true,
+    onSelectionChange: true,
+    mostRecentEventCount: true,
+    inlineImageLeft: true,
+    editable: true,
+    fontVariant: true,
+    borderBottomRightRadius: true,
+    borderBottomColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    borderRadius: true,
+    borderRightColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    borderColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    borderTopRightRadius: true,
+    borderStyle: true,
+    borderBottomLeftRadius: true,
+    borderLeftColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+    borderTopLeftRadius: true,
+    borderTopColor: {process: require('react-native/Libraries/StyleSheet/processColor')},
+  },
+};
+
 let AndroidTextInputNativeComponent;
 if (global.RN$Bridgeless) {
-  ReactNativeViewConfigRegistry.register('AndroidInputTextBbd', () => {
-    return AndroidTextInputViewConfig;
-  });
+  ReactNativeViewConfigRegistry.register('AndroidInputTextBbd', () => __INTERNAL_VIEW_CONFIG);
   AndroidTextInputNativeComponent = 'AndroidInputTextBbd';
 } else {
   AndroidTextInputNativeComponent = requireNativeComponent<NativeProps>(

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/js/TextInput.android.js
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/js/TextInput.android.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  * Some modifications to the original TextInput UI component for react-native
  * from https://github.com/facebook/react-native
  *
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const DeprecatedTextInputPropTypes = require('react-native/Libraries/DeprecatedPropTypes/DeprecatedTextInputPropTypes');
+const DeprecatedTextInputPropTypes = require('deprecated-react-native-prop-types').TextInputPropTypes;
 const Platform = require('react-native/Libraries/Utilities/Platform');
 const React = require('react');
 const ReactNative = require('react-native/Libraries/Renderer/shims/ReactNative');

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/package.json
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-TextInput/package.json
@@ -10,5 +10,8 @@
   "keywords": [
     "react-native"
   ],
-  "license": "SEE LICENSE IN LICENSE"
+  "license": "SEE LICENSE IN LICENSE",
+  "dependencies": {
+    "deprecated-react-native-prop-types": "^2.2.0"
+  }
 }

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/README.md
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/README.md
@@ -12,10 +12,11 @@ Secures `<WebView />` UI component provided by [react-native-webview@10.8.3](htt
 - [x] Android
 
 #### React Native
- - 0.63.x (deprecated)
- - 0.64.x
- - 0.65.x
- - 0.66.x (0.66.1 is latest supported)
+ - 0.64.x (deprecated)
+ - 0.65.x (deprecated)
+ - 0.66.x
+ - 0.67.x
+ - 0.68.x (0.68.2 is latest supported)
 
 #### Supported on iOS and Android
  - HTTP redirection
@@ -24,9 +25,9 @@ Secures `<WebView />` UI component provided by [react-native-webview@10.8.3](htt
  - Page resource and content loading
  - MTD Safe browsing
  - DLP (secure cut/copy/paste) within WebView
+ - Browsing history - `GoBack`, `GoForward`, `Reload` and `StopLoading` API
 
  #### Supported on iOS and not supported on Android
- - Browsing history - `GoBack`, `GoForward`, `Reload` and `StopLoading` API
  - AutoZSO
 
 #### Not supported on iOS and Android
@@ -80,6 +81,3 @@ For more, read the [API Reference](https://github.com/react-native-community/rea
     $ cd ios
     $ pod install
     $ cd ..
-
-## Known issues
- - [Android] Response with error message is not shown for unsuccessful request

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/build.gradle
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/build.gradle
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 BlackBerry Limited. All Rights Reserved.
+ * Copyright (c) 2022 BlackBerry Limited. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,16 +25,16 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
-            classpath("com.android.tools.build:gradle:3.6.0")
+            classpath("com.android.tools.build:gradle:4.2.2")
             classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getExtOrDefault('kotlinVersion')}")
         }
     } else {
         repositories {
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -62,9 +62,9 @@ android {
 def kotlin_version = getExtOrDefault('kotlinVersion')
 
 dependencies {
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:+'
-    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:+'
-    implementation 'com.blackberry.blackberrydynamics:android_webview:+'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_platform:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_handheld_backup_support:10.2.0.79'
+    implementation 'com.blackberry.blackberrydynamics:android_webview:10.2.0.79'
     implementation project(path: ':BlackBerry-Dynamics-for-React-Native-Base')
     implementation "com.facebook.react:react-native:+"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/gradle.properties
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/gradle.properties
@@ -1,4 +1,4 @@
 ReactNativeWebView_kotlinVersion=1.5.10
-ReactNativeWebView_compileSdkVersion=29
-ReactNativeWebView_buildToolsVersion=29.0.3
-ReactNativeWebView_targetSdkVersion=28
+ReactNativeWebView_compileSdkVersion=30
+ReactNativeWebView_buildToolsVersion=30.0.0
+ReactNativeWebView_targetSdkVersion=30

--- a/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/src/main/java/com/blackberry/bbd/reactnative/ui/webview/RNCWebViewManager.java
+++ b/ui-components/BlackBerry-Dynamics-for-React-Native-WebView/android/src/main/java/com/blackberry/bbd/reactnative/ui/webview/RNCWebViewManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 BlackBerry Limited.
+ * Copyright (c) 2022 BlackBerry Limited.
  *
  * Some modifications to the original <WebView /> UI component
  * from https://github.com/react-native-community/react-native-webview/blob/v10.8.3
@@ -61,7 +61,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.core.util.Pair;
 
-import com.blackberry.bbwebview.BBChromeClient;
+import com.blackberry.bbwebview.BBWebChromeClient;
 import com.blackberry.bbwebview.BBWebViewClient;
 import com.blackberry.bbwebview.BBWebView;
 import com.facebook.common.logging.FLog;
@@ -615,7 +615,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches
     bbWebViewClient = new RNCWebViewClient();
-    BBWebViewClient.init(view,bbWebViewClient);
+    bbWebViewClient.initializeClient(reactContext.getApplicationContext());
     view.setWebViewClient(bbWebViewClient);
   }
 
@@ -1075,7 +1075,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
-  protected static class RNCWebChromeClient extends BBChromeClient implements LifecycleEventListener {
+  protected static class RNCWebChromeClient extends BBWebChromeClient implements LifecycleEventListener {
     protected static final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
       LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER);
 
@@ -1103,7 +1103,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
 
     public RNCWebChromeClient(ReactContext reactContext, WebView webView) {
-      super(((BBWebViewClient) webView.getWebViewClient()).getObserver());
       this.mReactContext = reactContext;
       this.mWebView = webView;
     }


### PR DESCRIPTION
	- added support for React Native 0.67, 0.68
	- deprecated support for React Native 0.64, 0.65
	- added support for BlackBerry Dynamics SDK for iOS v10.2, BlackBerry Dynamics SDK for Android v10.2
	- implemented BlackBerry-Dynamics-for-React-Native-Application module and Policy sample app
	- added possibility to use locally downloaded Dynamics SDK for iOS in Base module
	- added other minor improvements and defect fixes